### PR TITLE
Trans(guide/animations.jade), Trans(guide/cheatsheet.jade), Trans(cookbook/_data.json), Trans(glossary.jade)

### DIFF
--- a/public/docs/ts/latest/cookbook/_data.json
+++ b/public/docs/ts/latest/cookbook/_data.json
@@ -12,7 +12,7 @@
 
   "ajs-quick-reference": {
     "title": "AngularJS에서 Angular로의 빠른 참조",
-    "navTitle": "AngularJS에서 Angular로의 빠른 참조",
+    "navTitle": "AngularJS에서 Angular로 전환",
     "intro": "AngularJS 개념과 기법이 Angular에 어떻게 매핑되는 알아보기"
   },
 

--- a/public/docs/ts/latest/glossary.jade
+++ b/public/docs/ts/latest/glossary.jade
@@ -641,7 +641,7 @@ a#jit
   :marked
     Angular _실시간_ 부트스트래핑으로 여러분은 브라우저 내에 존재하는 여러분의 컴포넌트와 
     모듈을 컴파일할 수 있으며 애플리케이션을 동적으로 실행할 수 있습니다. 이는 개발 과정에서 좋은 선택지입니다. 
-    생산용 앱을 대상으로 [AOT 컴파일](#aot) 모드를 권장합니다.  
+    상용 앱을 대상으로 할 때는 [AOT 컴파일](#aot) 모드를 권장합니다.  
 
     With Angular _just-in-time_  bootstrapping you compile your components<span if-docs="ts"> and modules</span> in the browser
     and launch the application dynamically. This is a good choice during development.

--- a/public/docs/ts/latest/guide/animations.jade
+++ b/public/docs/ts/latest/guide/animations.jade
@@ -1,10 +1,19 @@
 include ../_util-fns
 
 :marked
+  모션은 모던 웹 어플리케이션의 디자인에서 중요한 부분입니다.
+  훌륭한 사용자 인터페이스는 필요한 곳에서 주의를 환기시키는 흥미진진한 애니메이션으로
+  상태 사이를 원활하게 전환합니다. 잘 디자인 된 애니메이션은
+  UI를 재미있게 할뿐 아니라 사용하기 편하게 합니다.
+
   Motion is an important aspect in the design of modern web applications. Good
   user interfaces transition smoothly between states with engaging animations
   that call attention where it's needed. Well-designed animations can make a UI not only
   more fun but also easier to use.
+
+  Angular의 애니메이션 시스템을 사용하면 순수한 CSS 애니메이션과 동일한 기본 성능으로
+  실행되는 애니메이션을 제작할 수 있습니다. 애니메이션 로직을 나머지 어플리케이션 코드와
+  긴밀하게 통합하여 손쉽게 제어 할 수 있습니다.
 
   Angular's animation system lets you build animations that run with the same kind of native
   performance found in pure CSS animations. You can also tightly integrate your
@@ -12,8 +21,14 @@ include ../_util-fns
 
 .alert.is-helpful
   :marked
+    Angular 애니메이션은 표준 [웹 애니메이션 API](https://w3c.github.io/web-animations/)에 따라 구축되었으며
+    이를 [지원하는 브라우저](http://caniuse.com/#feat=web-animation)에서 실행됩니다.
+
     Angular animations are built on top of the standard [Web Animations API](https://w3c.github.io/web-animations/)
     and run natively on [browsers that support it](http://caniuse.com/#feat=web-animation).
+
+    다른 브라우저에서는 polyfill이 필요합니다.
+    GitHub의 [`web-animations.min.js`](https://github.com/web-animations/web-animations-js)를 페이지에 추가하세요.
 
     For other browsers, a polyfill is required. Grab
     [`web-animations.min.js` from GitHub](https://github.com/web-animations/web-animations-js) and
@@ -21,32 +36,71 @@ include ../_util-fns
 
 
 :marked
+  # 내용
   # Contents
 
+  * [예: 두 가지 상태간 전환(Transition)](#example-transitioning-between-states).
+
   * [Example: Transitioning between two states](#example-transitioning-between-states).
+
+  * [상태와 전환](#states-and-transitions).
+
   * [States and transitions](#states-and-transitions).
+
+  * [예: 진입과 이탈](#example-entering-and-leaving).
+
   * [Example: Entering and leaving](#example-entering-and-leaving).
+
+  * [예: 다른 상태로부터의 진입과 이탈](#example-entering-and-leaving-from-different-states).
+
   * [Example: Entering and leaving from different states](#example-entering-and-leaving-from-different-states).
+
+  * [애니메이션 가능한 프로퍼티와 유닛](#animatable-properties-and-units).
+
   * [Animatable properties and units](#animatable-properties-and-units).
+
+  * [자동 프로퍼티 계산](#automatic-property-calculation).
+
   * [Automatic property calculation](#automatic-property-calculation).
+
+  * [애니메이션 타이밍](#animation-timing).
+
   * [Animation timing](#animation-timing).
+
+  * [keyframe을 활용한 다단계 애니메이션](#multi-step-animations-with-keyframes).
+
   * [Multi-step animations with keyframes](#multi-step-animations-with-keyframes).
+
+  * [병렬 애니메이션 그룹](#parallel-animation-groups).
+
   * [Parallel animation groups](#parallel-animation-groups).
+
+  * [애니메이션 콜백](#animation-callbacks).
+
   * [Animation callbacks](#animation-callbacks).
 
 .l-sub-section
   :marked
+      이 페이지의 예제는 <live-example></live-example> 에서 확인 가능합니다.
+
       The examples in this page are available as a <live-example></live-example>.
 
 a(id="example-transitioning-between-states")
 .l-main-section
 :marked
+  ## 빠른시작 예제: 두 가지 상태간 전환(Transition)
   ## Quickstart example: Transitioning between two states
 figure
   img(src="/resources/images/devguide/animations/animation_basic_click.gif" alt="A simple transition animation" align="right" style="width:220px;margin-left:20px" )
 :marked
+  모델 속성에 의해 구동되는 두 상태 사이에서
+  엘리먼트를 전환하는 간단한 애니메이션을 만들 수 있습니다.
+
   You can build a simple animation that transitions an element between two states
   driven by a model attribute.
+
+  애니메이션은 `@Component` 메타데이터 내에 정의됩니다.
+  애니메이션을 추가하기 전에 몇 가지 애니메이션 관련 기능을 임포트 해야합니다.
 
   Animations are defined inside `@Component` metadata. Before you can add animations, you need
   to import a few animation-specific functions:
@@ -54,6 +108,10 @@ figure
 +makeExample('animations/ts/src/app/hero-list-basic.component.ts', 'imports')(format=".")
 
 :marked
+  이것들을 사용하여 컴포넌트 메타데이터에서 `heroState`라 불리는 *애니메이션 트리거*를 정의 할 수 있습니다.
+  애니메이션을 사용하여 두 상태 (`활성 상태`와 `비활성 상태`) 사이를 전환합니다.
+  히어로가 활성화되면 엘리먼트가 약간 큰 크기와 밝은 색으로 나타납니다.
+
   With these, you can define an *animation trigger* called `heroState` in the component
   metadata. It uses animations to transition between two states: `active` and `inactive`. When a
   hero is active, the element appears in a slightly larger size and lighter color.
@@ -62,19 +120,32 @@ figure
 
 .alert.is-helpful
   :marked
+    이 예제에서는 애니메이션 메타데이터에서 인라인으로
+    애니메이션 스타일 (색상 및 변형)을 정의하고 있습니다.
+
     In this example, you are defining animation styles (color and transform) inline in the
     animation metadata.
 
 :marked
+  이제 `[@triggerName]` 구문을 사용하여, 방금 정의한 애니메이션을
+  컴포넌트 템플릿의 여러 엘리먼트에 붙이세요.
+
   Now, using the `[@triggerName]` syntax, attach the animation that you just defined to
   one or more elements in the component's template.
 
 +makeExample('animations/ts/src/app/hero-list-basic.component.ts', 'template')(format=".")
 
 :marked
+  여기서 애니메이션 트리거는 `ngFor`에 의해 반복되는 모든 엘리먼트에 적용됩니다.
+  반복되는 각 엘리먼트는 독립적으로 움직입니다.
+  속성의 값은 `hero.state`라는 표현식에 바인딩되어 있으며 항상 `active` 또는 `inactive`입니다.
+
   Here, the animation trigger applies to every element repeated by an `ngFor`. Each of
   the repeated elements animates independently. The value of the
   attribute is bound to the expression `hero.state` and is always either `active` or `inactive`.
+
+  이 설정을 사용하면 히어로 객체가 상태를 바꿀 때마다 애니메이션 전환이 일어납니다.
+  전체 컴포넌트 구현은 다음과 같습니다.
 
   With this setup, an animated transition appears whenever a hero object changes state.
   Here's the full component implementation:
@@ -82,10 +153,17 @@ figure
 +makeExample('animations/ts/src/app/hero-list-basic.component.ts')
 
 :marked
+  ## 상태(state) 및 전환(transition)
   ## States and transitions
+  Angular 애니메이션은 상태 사이의 논리적 **상태** 및 **전환**으로 정의됩니다.
 
   Angular animations are defined as logical **states** and **transitions**
   between states.
+
+  애니메이션 상태는 애플리케이션 코드에서 정의하는 문자열 값입니다.
+  위의 예에서 상태 `'active'`및 `'inactive'`는 히어로 객체의 논리적 상태를 기반으로 합니다.
+  상태의 소스는 이 경우처럼 간단한 객체 속성일 수도 있고 메소드에서 계산 된 값일 수도 있습니다.
+  중요한 것은 그 값을 구할 수 있다는 것입니다.
 
   An animation state is a string value that you define in your application code. In the example
   above, the states `'active'` and `'inactive'` are based on the logical state of
@@ -93,14 +171,23 @@ figure
   or it can be a value computed in a method. The important thing is that you can read it into the
   component's template.
 
+  각 애니메이션 상태에 대해 *스타일*을 정의 할 수 있습니다.
+
   You can define *styles* for each animation state:
 
 +makeExample('animations/ts/src/app/hero-list-basic.component.ts', 'states')(format=".")
 
 :marked
+  이 `state` 정의는 각 상태의 *end 스타일*을 지정합니다.
+  이것들은 그 상태로 옮겨 졌을 때 엘리먼트에 적용되고, *그 상태로 남아있는 한* 상태를 유지합니다.
+  실제로 다른 엘리먼트 상태의 스타일을 정의했습니다.
+
   These `state` definitions specify the *end styles* of each state.
   They are applied to the element once it has transitioned to that state, and stay
   *as long as it remains in that state*. In effect, you're defining what styles the element has in different states.
+
+  상태를 정의한 후에 상태 사이의 *전환(transition)*을 정의 할 수 있습니다.
+  각 전환은 한 세트의 스타일과 다음 세트 간의 전환 타이밍을 제어합니다.
 
   After you define states, you can define *transitions* between the states. Each transition
   controls the timing of switching between one set of styles and the next:
@@ -111,18 +198,29 @@ figure.image-display
   img(src="/resources/images/devguide/animations/ng_animate_transitions_inactive_active.png" alt="In Angular animations you define states and transitions between states" width="400")
 
 :marked
+  여러 개의 트랜지션이 동일한 타이밍 설정을 가지고 있다면,
+  같은 `transition` 정의로 결합 할 수 있습니다:
+
   If several transitions have the same timing configuration, you can combine
   them into the same `transition` definition:
 
 +makeExample('animations/ts/src/app/hero-list-combined-transitions.component.ts', 'transitions')(format=".")
 
 :marked
+  이전 예제에서와 같이 전환의 양방향이 같은 타이밍을 가질 때
+  `<=>`의 약식 구문을 사용할 수 있습니다:
+
   When both directions of a transition have the same timing, as in the previous
   example, you can use the shorthand syntax `<=>`:
 
 +makeExample('animations/ts/src/app/hero-list-twoway.component.ts', 'transitions')(format=".")
 
 :marked
+  애니메이션 도중에만 적용하고 애니메이션이 끝난 후에는 적용하지 않는 스타일을 정의할 수도 있습니다.
+  그런 스타일을 `transition` 안에 인라인으로 정의 할 수 있습니다. 이 예제에서 엘리먼트는 한 세트의 스타일을
+  즉시 적용한 후 다음 스타일로 움직입니다. 전환이 끝나면 '상태'에 정의되지 않았기 때문에
+  이러한 스타일이 유지되지 않습니다.
+
   You can also apply a style during an animation but not keep it around
   after the animation finishes. You can define such styles inline, in the `transition`. In this example,
   the element receives one set of styles immediately and is then animated to the next.
@@ -132,12 +230,20 @@ figure.image-display
 +makeExample('animations/ts/src/app/hero-list-inline-styles.component.ts', 'transitions')(format=".")
 
 :marked
+  ### 와일드카드 상태 `*`
   ### The wildcard state `*`
+
+  `*` ("와일드카드") 상태는 모든 애니메이션 상태와 일치합니다. 이는 애니메이션이 어떤 상태에 있는지 관계없이 적용되는 스타일이나 전환을 정의 할 때 유용합니다. 예를 들면 다음과 같습니다.
 
   The `*` ("wildcard") state matches *any* animation state. This is useful for defining styles and
   transitions that apply regardless of which state the animation is in. For example:
 
+  * `active => *` 전환은 엘리먼트의 상태가 `활성`에서 다른 것으로 변경 될 때 적용됩니다.
+
   * The `active => *` transition applies when the element's state changes from `active` to anything else.
+
+  * `* => *` 전환은 두 상태 사이의 *어떤* 변화가 일어날 때 적용됩니다.
+
   * The `* => *` transition applies when *any* change between two states takes place.
 
 figure.image-display
@@ -145,12 +251,20 @@ figure.image-display
 
 
 :marked
+  ### `void '상태
   ### The `void` state
+
+  `void`라고 불리는 특별한 상태는 모든 애니메이션에 적용될 수 있습니다.
+  이것은 엘리먼트가 뷰에 연결되지 않았을 때 적용됩니다. 아마도 엘리먼트가 아직 추가되지 않았거나 제거 되었기 때문일 것입니다.
+  `void` 상태는 애니메이션 입력 및 이탈을 정의하는 데 유용합니다.
 
   The special state called `void` can apply to any animation. It applies
   when the element is *not* attached to a view, perhaps because it has not yet been
   added or because it has been removed. The `void` state is useful for defining enter and
   leave animations.
+
+  예를 들어 `* => void` 전환은 엘리먼트가 뷰에서 이탈할 때
+  이전의 상태와 관계없이 적용됩니다.
 
   For example the `* => void` transition applies when the element leaves the view,
   regardless of what state it was in before it left.
@@ -159,21 +273,38 @@ figure.image-display
   img(src="/resources/images/devguide/animations/ng_animate_transitions_void_in.png" alt="The void state can be used for enter and leave transitions" width="400")
 
 :marked
+  와일드 카드 상태 `*`도 `void`와 일치합니다.
+
   The wildcard state `*` also matches `void`.
+
+  ## 예: 진입과 이탈
 
   ## Example: Entering and leaving
 figure
   img(src="/resources/images/devguide/animations/animation_enter_leave.gif" alt="Enter and leave animations" align="right" style="width:250px;" )
 :marked
+  `void` 와 `*` 상태를 사용하면 엘리먼트가 진입하고 이탈하는 것을
+  애니메이션화하는 전환으로 정의 할 수 있습니다:
+
   Using the `void` and `*` states you can define transitions that animate the
   entering and leaving of elements:
 
+  * 진입: `void => *`
+
   * Enter: `void => *`
+
+  * 이탈: `* => void`
+
   * Leave: `* => void`
 
 +makeExample('animations/ts/src/app/hero-list-enter-leave.component.ts', 'animationdef')(format=".")
 
 :marked
+  이 경우 스타일은 전환 정의에 따라 직접 void 상태에 적용되고, 별도의
+  `state(void)` 정의에서 적용되는 것이 아니라는 것에 유의하세요.
+  따라서 변형(transform)은 입력 및 이탈 시에 다릅니다:
+  엘리먼트는 왼쪽에서 들어오고 오른쪽으로 나갑니다.
+
   Note that in this case the styles are applied to the void state directly in the
   transition definitions, and not in a separate `state(void)` definition. Thus, the transforms
   are different on enter and leave: the element enters from the left
@@ -181,25 +312,45 @@ figure
 
 .l-sub-section
   :marked
+    이 두 가지 공통 애니메이션에는 고유 한 별칭이 있습니다:
+
     These two common animations have their own aliases:
   code-example(language="typescript").
     transition(':enter', [ ... ]); // void => *
     transition(':leave', [ ... ]); // * => void
 
 :marked
+  ## 예: 다른 상태에서의 진입과 이탈
   ## Example: Entering and leaving from different states
 figure
   img(src="/resources/images/devguide/animations/animation_enter_leave_states.gif" alt="Enter and leave animations combined with state animations" align="right" style="width:200px" )
 :marked
+  히어로 상태를 애니메이션 상태로 사용하여 이 애니메이션을 이전 상태 전환
+  애니메이션과 결합 할 수도 있습니다.
+  히어로의 상태에 따라 입출력을 위한 다양한 전환을 구성 할 수 있습니다.
+
   You can also combine this animation with the earlier state transition animation by
   using the hero state as the animation state. This lets you configure
   different transitions for entering and leaving based on what the state of the hero
   is:
 
+  * 비활성 히어로 진입: `void => inactive`
+
   * Inactive hero enter: `void => inactive`
+
+  * 활성 히어로 진입: `void => active`
+
   * Active hero enter: `void => active`
+
+  * 비활성 히어로 이탈: `inactive => void`
+
   * Inactive hero leave: `inactive => void`
+
+  * 활성 히어로 이탈 : `active => void`
+
   * Active hero leave: `active => void`
+
+  이렇게 하면 각 전환에 대해 세밀한 제어가 가능합니다:
 
   This gives you fine-grained control over each transition:
 
@@ -210,13 +361,23 @@ figure.image-display
 +makeExample('animations/ts/src/app/hero-list-enter-leave-states.component.ts', 'animationdef')(format=".")
 
 :marked
+  ## 애니메이션 가능한 속성 및 단위
   ## Animatable properties and units
+
+  Angular의 애니메이션 지원은 Web Animations에 기반해 구축 되었기 때문에
+  브라우저에서 *애니메이션화 할 수 있는* 모든 속성을 애니메이션으로 만들 수 있습니다.
+  여기에는 위치, 크기, 변형, 색상, 테두리 및 기타 여러 항목이 포함됩니다.
+  W3C는 [CSS 변환 페이지](https://www.w3.org/TR/css3-transitions)에서
+  [애니메이션 속성 목록](https://www.w3.org/TR/css3-transitions/#animatable-properties)을 유지 관리합니다.
 
   Since Angular's animation support builds on top of Web Animations, you can animate any property
   that the browser considers *animatable*. This includes positions, sizes, transforms, colors,
   borders, and many others. The W3C maintains
   [a list of animatable properties](https://www.w3.org/TR/css3-transitions/#animatable-properties)
   on its [CSS Transitions page](https://www.w3.org/TR/css3-transitions).
+
+  숫자 값이 있는 위치 속성의 경우 값을 적절한 접미어와 함께
+  문자열을 제공하여 단위를 정의 할 수 있습니다.
 
   For positional properties that have a numeric value, you can define a unit by providing
   the value as a string with the appropriate suffix:
@@ -225,21 +386,36 @@ figure.image-display
   * `'3em'`
   * `'100%'`
 
+  치수를 지정할 때 단위를 제공하지 않으면 Angular는 기본적으로 `px`를 사용합니다:
+
   If you don't provide a unit when specifying dimension, Angular assumes the default of `px`:
+
+  * `50`은 '50px'와 동일합니다.
 
   * `50` is the same as saying `'50px'`
 
+  ## 자동 속성 계산
   ## Automatic property calculation
 figure
   img(src="/resources/images/devguide/animations/animation_auto.gif" alt="Animation with automated height calculation" align="right" style="width:220px;margin-left:20px" )
 :marked
+  때로는 런타임까지 스타일 속성의 치수를 알 수 없는 경우가 있습니다.
+  예를 들어, 엘리먼트는 내용 및 화면 크기에 따라 폭과 높이가 정해지는 경우가 많습니다.
+  이러한 프로퍼티에 CSS 애니메이션을 적용하는 것은 종종 까다롭습니다.
+
   Sometimes you don't know the value of a dimensional style property until runtime.
   For example, elements often have widths and heights that
   depend on their content and the screen size. These properties are often tricky
   to animate with CSS.
 
+  이 경우 특별한 `*` 프로퍼티 값을 사용하여
+  프로퍼티 값을 런타임에 계산한 다음 애니메이션에 연결할 수 있습니다.
+
   In these cases, you can use a special `*` property value so that the value of the
   property is computed at runtime and then plugged into the animation.
+
+  이 예제에서, 이탈 애니메이션은 엘리먼트가 이탈하기 전에 엘리먼트 높이를 가져 와서
+  해당 높이부터 0으로 애니메이션합니다.
 
   In this example, the leave animation takes whatever height the element has before it
   leaves and animates from that height to zero:
@@ -247,30 +423,61 @@ figure
 +makeExample('animations/ts/src/app/hero-list-auto.component.ts', 'animationdef')(format=".")
 
 :marked
+  ## 애니메이션 타이밍
   ## Animation timing
+
+  모든 애니메이션 전환에 대해 조정할 수 있는 세 가지 시간 속성이 있습니다:
+  duration, delay, easing function.
+  이것들은 모두 단일 전환 *타이밍 문자열*로 결합됩니다.
 
   There are three timing properties you can tune for every animated transition:
   the duration, the delay, and the easing function. They are all combined into
   a single transition *timing string*.
 
   ### Duration
+  ### Duration
+
+  duration은 애니메이션이 처음부터 끝까지 실행되는 데 걸리는 시간을 제어합니다.
+  다음과 같은 세 가지 방법으로 duration을 정의 할 수 있습니다.
 
   The duration controls how long the animation takes to run from start to finish.
   You can define a duration in three ways:
 
+  * 밀리초 단위의 순수 숫자: `100`
+
   * As a plain number, in milliseconds: `100`
+
+  * 밀리초 단위의 문자열: `'100ms'`
+
   * In a string, as milliseconds: `'100ms'`
+
+  * 초 단위의 문자열: `'0.1s'`
+
   * In a string, as seconds: `'0.1s'`
 
   ### Delay
+  ### Delay
+
+  delay는 애니메이션 트리거와 전환 시작 사이의 시간을 제어합니다.
+  duration 문자열 뒤쪽에 추가하여 정의할 수 있습니다.
+  또한 duration과 동일한 option format을 가집니다.
 
   The delay controls the length of time between the animation trigger and the beginning
   of the transition. You can define one by adding it to the same string
   following the duration. It also has the same format options as the duration:
 
+  * 100ms 대기 후 200ms 동안 실행: `'0.2s 100ms'`
+
   * Wait for 100ms and then run for 200ms: `'0.2s 100ms'`
 
   ### Easing
+  ### Easing
+
+  [easing 함수](http://easings.net/)는 런타임 동안 애니메이션이
+  가속 및 감속하는 방법을 제어합니다. 예를 들어, `ease-in` 함수는
+  애니메이션이 상대적으로 느리게 시작하지만 진행 속도가 빨라집니다.
+  duration 이후 문자열에 *세 번째* 값을 추가하여 (또는 delay가 없을 경우 *두 번째* 값으로)
+  easing을 제어 할 수 있습니다.
 
   The [easing function](http://easings.net/) controls how the animation accelerates
   and decelerates during its runtime. For example, an `ease-in` function causes
@@ -278,13 +485,23 @@ figure
   can control the easing by adding it as a *third* value in the string after the duration
   and the delay (or as the *second* value when there is no delay):
 
+  * 100ms 대기 후 200ms 동안 easing과 함께 실행: `'0.2s 100ms ease-out'`
+
   * Wait for 100ms and then run for 200ms, with easing: `'0.2s 100ms ease-out'`
+
+  * easing과 함께 200ms 실행: `'0.2s ease-in-out'`
+
   * Run for 200ms, with easing: `'0.2s ease-in-out'`
 
 figure
   img(src="/resources/images/devguide/animations/animation_timings.gif" alt="Animations with specific timings" align="right" style="width:220px;margin-left:20px" )
 :marked
+  ### 예제
   ### Example
+
+  다음은 몇 가지 사용자 정의 타이밍입니다.
+  둘 다 200ms 동안 계속 진입하고 이탈을 하지만 서로 다른 easing을 합니다.
+  약간의 지체 후에 이탈이 시작됩니다.
 
   Here are a couple of custom timings in action. Both enter and leave last for
   200 milliseconds but they have different easings. The leave begins after a
@@ -293,16 +510,27 @@ figure
 +makeExample('animations/ts/src/app/hero-list-timings.component.ts', 'animationdef')(format=".")
 
 :marked
+  ## keyframes를 사용한 다단계 애니메이션
   ## Multi-step animations with keyframes
 figure
   img(src="/resources/images/devguide/animations/animation_multistep.gif" alt="Animations with some bounce implemented with keyframes" align="right" style="width:220px;margin-left:20px" )
 :marked
+  애니메이션 *keyframes*는 간단한 전환 이상의 것을 하기 위한 것으로,
+  두 가지 스타일 세트를 전환하면서 하나 이상의 중간 스타일을 통과하는 보다 복잡한 애니메이션입니다.
+
   Animation *keyframes* go beyond a simple transition to a more intricate animation
   that goes through one or more intermediate styles when transitioning between two sets of styles.
+
+  각 keyframe에 대해 *offset*을 지정합니다.
+  keyframe이 적용되는 애니메이션에서 오프셋은 애니메이션의 시작을 나타내는 0과
+  끝을 나타내는 1 사이의 숫자입니다.
 
   For each keyframe, you specify an *offset* that defines at which point
   in the animation that keyframe applies. The offset is a number between zero,
   which marks the beginning of the animation, and one, which marks the end.
+
+  다음 예제는 keyframe을 사용하여 
+  진입과 이탈 시점에 애니메이션을 추가합니다.
 
   This example adds some "bounce" to the enter and leave animations with
   keyframes:
@@ -310,25 +538,45 @@ figure
 +makeExample('animations/ts/src/app/hero-list-multistep.component.ts', 'animationdef')(format=".")
 
 :marked
+  오프셋은 절대 시간으로 정의하지 않는다는 것에 주의하세요.
+  0부터 1까지 상대적인 수치입니다. 애니메이션의 최종 타임 라인은
+  keyframe offset, duration, delay와 easing 조합을 기반으로 합니다.
+
   Note that the offsets are *not* defined in terms of absolute time. They are relative
   measures from zero to one. The final timeline of the animation is based on the combination
   of keyframe offsets, duration, delay, and easing.
+
+  keyframe에 대한 offset 정의는 선택 사항입니다.
+  이를 생략하면 간격이 균일한 offset이 자동으로 지정됩니다.
+  예를 들어, 미리 정의 된 offset이 없는 3개의 keyframe에는
+  `0`, `0.5` 및 `1` 오프셋이 제공됩니다.
 
   Defining offsets for keyframes is optional. If you omit them, offsets with even
   spacing are automatically assigned. For example, three keyframes without predefined
   offsets receive offsets `0`, `0.5`, and `1`.
 
 :marked
+  ## 병렬 애니메이션 그룹
   ## Parallel animation groups
 figure
   img(src="/resources/images/devguide/animations/animation_groups.gif" alt="Parallel animations with different timings, implemented with groups" align="right" style="width:220px;margin-left:20px" )
 :marked
+  동시에 여러 스타일 속성에 애니메이션을 적용하는 방법을 살펴보았습니다.
+  모든 스타일을 동일한 `style()` 정의에 넣기만 하면 됩니다.
+
   You've seen how to animate multiple style properties at the same time:
   just put all of them into the same `style()` definition.
+
+  그러나 병렬로 발생하는 애니메이션에 대해 다른 *타이밍*을 구성 할 수도 있습니다.
+  예를 들어 두 개의 CSS 속성에 애니메이션을 적용하고 각 CSS 속성에 대해 다른 easing function을 사용할 수 있습니다.
 
   But you may also want to configure different *timings* for animations that happen
   in parallel. For example, you may want to animate two CSS properties but use a
   different easing function for each one.
+
+  이를 위해 애니메이션 *그룹*을 사용할 수 있습니다.
+  이 예에서, 진입과 이탈시 그룹을 사용하면 두 가지 다른 타이밍 구성이 가능합니다.
+  두 가지 모두 같은 엘리먼트에 병렬로 적용되지만 서로 독립적으로 실행됩니다.
 
   For this you can use animation *groups*. In this example, using groups both on
   enter and leave allows for two different timing configurations. Both
@@ -337,12 +585,20 @@ figure
 +makeExample('animations/ts/src/app/hero-list-groups.component.ts', 'animationdef')(format=".")
 
 :marked
+  하나의 그룹은 엘리먼트 변형 및 폭을 애니메이션화합니다. 다른 그룹은 투명도를 애니메이션화합니다.
+
   One group animates the element transform and width; the other group animates the opacity.
 
 :marked
+  ## 애니메이션 콜백
   ## Animation callbacks
 
+  콜백은 애니메이션이 시작될 때와 완료될 때 호출됩니다.
+
   A callback is fired when an animation is started and also when it is done.
+
+  keyframes 예제에서, `@flyInOut` 이라고 불리는 `trigger`를 가지고 있습니다.
+  이런 경우 다음과 같이 콜백을 연결할 수 있습니다.
 
   In the keyframes example, you have a `trigger` called `@flyInOut`. There you can hook
   those callbacks like this:
@@ -350,7 +606,12 @@ figure
 +makeExample('animations/ts/src/app/hero-list-multistep.component.ts', 'template')(format=".")
 
 :marked
+  콜백은 `fromState`, `toState` 및 `totalTime`과 같은 유용한 속성을
+  가진 `AnimationTransitionEvent`를 수신합니다.
+
   The callbacks receive an `AnimationTransitionEvent` which contains useful properties such as `fromState`,
   `toState` and `totalTime`.
+
+  이러한 콜백은 애니메이션이 선택되었는지 여부에 관계없이 호출됩니다.
 
   Those callbacks will fire whether or not an animation is picked up.

--- a/public/docs/ts/latest/guide/animations.jade
+++ b/public/docs/ts/latest/guide/animations.jade
@@ -1,7 +1,7 @@
 include ../_util-fns
 
 :marked
-  모션은 모던 웹 어플리케이션의 디자인에서 중요한 부분입니다.
+  모션은 모던 웹 애플리케이션의 디자인에서 중요한 부분입니다.
   훌륭한 사용자 인터페이스는 필요한 곳에서 주의를 환기시키는 흥미진진한 애니메이션으로
   상태 사이를 원활하게 전환합니다. 잘 디자인 된 애니메이션은
   UI를 재미있게 할뿐 아니라 사용하기 편하게 합니다.
@@ -251,7 +251,7 @@ figure.image-display
 
 
 :marked
-  ### `void '상태
+  ### `void` 상태
   ### The `void` state
 
   `void`라고 불리는 특별한 상태는 모든 애니메이션에 적용될 수 있습니다.
@@ -383,7 +383,10 @@ figure.image-display
   the value as a string with the appropriate suffix:
 
   * `'50px'`
+  * `'50px'`
   * `'3em'`
+  * `'3em'`
+  * `'100%'`
   * `'100%'`
 
   치수를 지정할 때 단위를 제공하지 않으면 Angular는 기본적으로 `px`를 사용합니다:

--- a/public/docs/ts/latest/guide/cheatsheet.jade
+++ b/public/docs/ts/latest/guide/cheatsheet.jade
@@ -1,1 +1,4 @@
-extends ../cheatsheet
+- var base = current.path[4] ? '.' : './guide';
+
+.l-content-small.grid-fluid.docs-content.cheatsheet
+  ngio-cheatsheet(src= base + '/cheatsheet-ko.json')


### PR DESCRIPTION
cheatsheet-ko.json include 부분이 누락되어 
Trans(guide/cheatsheet.jade) 도 추가했습니다.

cookbook/_data.json에서 메뉴명이 길어서 두줄로 보이는 것이 있어서 한줄로 보이도록 수정했습니다.
"AngularJS에서 Angular로의 빠른 참조" => "AngularJS에서 Angular로 전환"

glossary.jade에서 일부 용어를 수정했습니다.
production apps: "생산용 앱" => "상용 앱"