### PR TITLE
Trans(cookbook/ajs-quick-reference.jade) & Solve the translated button issue

### DIFF
--- a/public/docs/ts/latest/cookbook/ajs-quick-reference.jade
+++ b/public/docs/ts/latest/cookbook/ajs-quick-reference.jade
@@ -1,7 +1,7 @@
 include ../_util-fns
 a(id="top")
 :marked
-  _Angular_는 오늘 그리고 앞으로 Angular를 위한 이름입니다.
+  _Angular_는 오늘 그리고 앞으로의 Angular를 위한 이름입니다.
   _AngularJS_는 모든 v1.x 버전 Angular의 이름입니다.
 
   _Angular_ is the name for the Angular of today and tomorrow.
@@ -43,7 +43,7 @@ a(id="top")
 
   * [Modules/controllers/components](#controllers-components) - *modules* in Angular are slightly different from *modules* in AngularJS, and *controllers* are *components* in Angular.
 
-  * [스타일 시트](#style-sheets) - AngularJS 보다 더 많은 CSS 옵션 제공.
+  * [스타일시트](#style-sheets) - AngularJS 보다 더 많은 CSS 옵션 제공.
 
   * [Style sheets](#style-sheets) - more options for CSS than in AngularJS.
 
@@ -94,14 +94,14 @@ table(width="100%")
       :marked
         Angular에서 중괄호로 묶인 템플릿 표현식은 여전히 단방향 바인딩을 나타냅니다.
         이것은 엘리먼트의 값을 컴포넌트의 프로퍼티에 바인당합니다.
-        바인딩 컨텍스트는 암시적이고 있고 항상 관련된 컴포넌트이므로, 참조 변수가 필요하지 않습니다.
+        바인딩 컨텍스트는 암묵적으로 항상 컴포넌트와 관련되어 있으므로 참조 변수가 필요하지 않습니다.
 
         In Angular, a template expression in curly braces still denotes one-way binding.
         This binds the value of the element to a property of the component.
         The context of the binding is implied and is always the
         associated component, so it needs no reference variable.
 
-        자세한 내용은, 템플릿 구문 페이지의 [삽입식](../guide/template-syntax.html#interpolation) 부분을 확인하세요.
+        자세한 내용은 템플릿 구문 페이지의 [삽입식](../guide/template-syntax.html#interpolation) 부분을 확인하세요.
 
         For more information, see the [Interpolation](../guide/template-syntax.html#interpolation) section of the Template Syntax page.
   tr(style=top)
@@ -132,7 +132,7 @@ table(width="100%")
         Many (but not all) of the built-in filters from AngularJS are
         built-in pipes in Angular.
 
-        자세한 내용은,아래의 [필터/파이프](#filters-pipes) 머릿말을 확인하세요.
+        자세한 내용은 아래의 [필터/파이프](#filters-pipes) 머릿말을 확인하세요.
 
         For more information, see the heading [Filters/pipes](#filters-pipes) below.
   tr(style=top)
@@ -145,7 +145,7 @@ table(width="100%")
           &lt;td>{{movie.title}}&lt;/td>
         &lt;/tr>
       :marked
-        여기, `movie`는 사용자가 정의한 지역변수입니다.
+        여기서 `movie`는 사용자가 정의한 지역변수입니다.
 
         Here, `movie` is a user-defined local variable.
     td
@@ -158,7 +158,7 @@ table(width="100%")
 
         Angular has true template input variables that are explicitly defined using the `let` keyword.
 
-        자세한 내용은, 템플릿 구문 페이지의 [ngFor 세부구문](../guide/template-syntax.html#ngForMicrosyntax) 부분을 확인하세요.
+        자세한 내용은 템플릿 구문 페이지의 [ngFor 세부구문](../guide/template-syntax.html#ngForMicrosyntax) 부분을 확인하세요.
 
         For more information, see the [ngFor micro-syntax](../guide/template-syntax.html#ngForMicrosyntax) section of the Template Syntax page.
 :marked
@@ -191,11 +191,11 @@ table(width="100%")
       code-example.
         &lt;body ng-app="movieHunter">
       :marked
-        애플리케이션의 시작 프로세스는 **부트스트래핑** 이라고 합니다.
+        애플리케이션의 시작 프로세스를 **부트스트래핑** 이라고 합니다.
 
         The application startup process is called **bootstrapping**.
 
-        코드에서 AngularJS 앱을 부트스트랩 할 수 있지만,
+        코드에서 AngularJS 앱을 부트스트랩할 수 있지만,
         많은 애플리케이션은 `ng-app` 지시자을 사용하여 선언적으로 부트스트랩을 수행하여,
         애플리케이션의 모듈(`movieHunter`) 이름을 제공합니다.
 
@@ -212,15 +212,15 @@ table(width="100%")
 
       :marked
         Angular에는 부트스트랩 지시자가 없습니다.
-        코드에서 앱을 실행하려면, 애플리케이션의 루트 모듈(`AppModule`)을 `main.ts`에 명시적으로 부트스트래핑하고
-        애플리케이션의 루트 컴포넌트 (`AppComponent`)는 `app.module.ts`에 부트스트랩하세요.
+        코드에서 앱을 실행하려면 애플리케이션의 루트 모듈(`AppModule`)을 `main.ts`에서 명시적으로 부트스트래핑하고
+        애플리케이션의 루트 컴포넌트 (`AppComponent`)는 `app.module.ts`에서 부트스트랩하세요.
         
         Angular doesn't have a bootstrap directive.
         To launch the app in code, explicitly bootstrap the application's root module (`AppModule`)
         in `main.ts`
         and the application's root component (`AppComponent`) in `app.module.ts`.
 
-        좀 더 자세한 내용은 [설치](../guide/setup.html) 페이지를 확인하세요.
+        자세한 내용은 [설치](../guide/setup.html) 페이지를 확인하세요.
 
         For more information see the [Setup](../guide/setup.html) page.
   tr(style=top)
@@ -234,18 +234,19 @@ table(width="100%")
                            shazam: isImportant}">
       :marked
         AngularJS에서는 `ng-class` 지시자가 표현식을 기반으로 CSS 클래스를 포함/제외합니다.
-        대게 이 표현식은 CSS 클래스 이름으로 정의된 객체의 키와 부울 값으로 평가된 템플릿 표현식으로 정의된 객체의 값으로 이루어진, 키-값 제어 객체입니다.
+        대게 이 표현식은 키-값 제어 객체입니다.
+        객체의 키는 CSS 클래스 이름으로 정의되어 있고, 값은 진위형 값으로 평가되는 템플릿 표현식으로 정의되어 있습니다.
 
         In AngularJS, the `ng-class` directive includes/excludes CSS classes
         based on an expression. That expression is often a key-value control object with each
         key of the object defined as a CSS class name, and each value defined as a template expression
         that evaluates to a Boolean value.
 
-        첫 번째 예제에서, `isActive`가 true이면 `active` 클래스가 엘리먼트에 적용됩니다.
+        첫 번째 예제에서 `isActive`가 true이면 `active` 클래스가 엘리먼트에 적용됩니다.
 
         In the first example, the `active` class is applied to the element if `isActive` is true.
     
-        두 번째 예제와 같이, 여러 클래스를 지정할 수 있습니다.
+        두 번째 예제와 같이 여러 클래스를 지정할 수 있습니다.
 
         You can specify multiple classes, as shown in the second example.
     td
@@ -273,7 +274,7 @@ table(width="100%")
         Angular also has **class binding**, which is a good way to add or remove a single class,
         as shown in the third example.
 
-        자세한 내용은, 템플릿 구문 페이지의 [속성, 클래스 및 스타일 바인딩](../guide/template-syntax.html#other-bindings) 부분을 확인하세요.
+        자세한 내용은 템플릿 구문 페이지의 [속성, 클래스 및 스타일 바인딩](../guide/template-syntax.html#other-bindings) 부분을 확인하세요.
 
         For more information see the [Attribute, Class, and Style Bindings](../guide/template-syntax.html#other-bindings) section of the Template Syntax page.
 
@@ -304,15 +305,15 @@ table(width="100%")
         ### bind to the `click` event
       +makeExample('cb-ajs-quick-reference/ts/src/app/app.component.html', 'event-binding')(format="." )
       :marked
-        AngularJS 이벤트에 기반한 지시자는 Angular에 존재하지 않습니다.
-        더 정확하게 이야기 하면, **이벤트 바인딩**을 사용하여 템플릿 뷰에서 컴포넌트로 단방향 바인딩을 정의하세요.
+        AngularJS 이벤트 기반 지시자는 Angular에 존재하지 않습니다.
+        더 정확하게 이야기 하면, **이벤트 바인딩**을 사용하여 템플릿 뷰에서 컴포넌트로 단방향 바인딩을 정의합니다.
 
         AngularJS event-based directives do not exist in Angular.
         Rather, define one-way binding from the template view to the component using **event binding**.
 
         이벤트 바인딩의 경우, 괄호 안에 대상 이벤트의 이름을 정의하고 등호의 오른쪽에 따옴표로 묶인 템플릿 명령문을 지정하세요.
         Angular는 대상 이벤트에 대한 이벤트 핸들러를 설정합니다.
-        이벤트가 발생하면 핸들러는 템플리트 명령문을 실행합니다.
+        이벤트가 발생하면 핸들러는 템플릿 명령문을 실행합니다.
 
         For event binding, define the name of the target event within parenthesis and
         specify a template statement, in quotes, to the right of the equals. Angular then
@@ -332,7 +333,7 @@ table(width="100%")
 
         For a list of DOM events, see: https://developer.mozilla.org/en-US/docs/Web/Events.
 
-        자세한 내용은, 템플릿 구문 페이지의 [이벤트 바인딩](../guide/template-syntax.html#event-binding) 부분을 확인하세요.
+        자세한 내용은 템플릿 구문 페이지의 [이벤트 바인딩](../guide/template-syntax.html#event-binding) 부분을 확인하세요.
 
         For more information, see the [Event Binding](../guide/template-syntax.html#event-binding) section of the Template Syntax page.
 
@@ -362,7 +363,7 @@ table(width="100%")
         In Angular, the template no longer specifies its associated controller.
         Rather, the component specifies its associated template as part of the component class decorator.
 
-        좀 더 자세한 내용은, [아키텍쳐 개요](../guide/architecture.html#component)를 확인하세요.
+        자세한 내용은 [아키텍쳐 개요](../guide/architecture.html#component)를 확인하세요.
 
         For more information, see [Architecture Overview](../guide/architecture.html#component).
 
@@ -371,7 +372,7 @@ table(width="100%")
       :marked
         ### ng-hide
         ### ng-hide
-        AngularJS에서 `ng-hide` 지시자는 표현식을 기반으로 연관된 HTML 요소를 표시하거나 숨깁니다.
+        AngularJS에서 `ng-hide` 지시자는 표현식을 기반으로 연관된 HTML 엘리먼트를 표시하거나 숨깁니다.
         좀 더 자세한 내용은 [ng-show](#ng-show)를 확인하세요.
 
         In AngularJS, the `ng-hide` directive shows or hides the associated HTML element based on
@@ -381,7 +382,7 @@ table(width="100%")
         ### `hidden` 프로퍼티에 바인딩
         ### bind to the `hidden` property
         Angular에서는 프로퍼티 바인딩을 사용합니다; 내장된 *hide* 지시자가 없습니다.
-        좀 더 자세한 내용은 [ng-show](#ng-show)를 확인하세요.
+        자세한 내용은 [ng-show](#ng-show)를 확인하세요.
 
         In Angular, you use property binding; there is no built-in *hide* directive.
         For more information, see [ng-show](#ng-show).
@@ -393,13 +394,13 @@ table(width="100%")
       code-example(format="").
         &lt;a ng-href="angularDocsUrl">Angular Docs&lt;/a>
       :marked
-        `ng-href` 지시자는 AngularJS가 브라우저에서 URL을 가져오기 전에 바인딩 표현식을 적절한 URL로 대체 할 수 있도록 `href` 속성을 전처리 할 수 있게 합니다.
+        `ng-href` 지시자는 AngularJS가 브라우저에서 URL을 가져오기 전에 바인딩 표현식을 적절한 URL로 대체할 수 있도록 `href` 속성을 전처리할 수 있게 합니다.
 
         The `ng-href` directive allows AngularJS to preprocess the `href` property so that it
         can replace the binding expression with the appropriate URL before the browser
         fetches from that URL.
 
-        AngularJS에서는 `ng-href`가 내비게이션의 일부로 라우트를 활성화하는 데 자주 사용됩니다.
+        AngularJS에서는 `ng-href`가 내비게이션의 일부로 route를 활성화하는 데 자주 사용됩니다.
 
         In AngularJS, the `ng-href` is often used to activate a route as part of navigation.
       code-example(format="").
@@ -420,17 +421,17 @@ table(width="100%")
         Angular, uses property binding; there is no built-in *href* directive.
         Place the element's `href` property in square brackets and set it to a quoted template expression.
 
-        프로퍼티 바인딩에 대한 좀 더 자세한 내용은, [템플릿 구문](../guide/template-syntax.html#property-binding)을 확인하세요.
+        프로퍼티 바인딩에 대한 좀 더 자세한 내용은  [템플릿 구문](../guide/template-syntax.html#property-binding)을 확인하세요.
 
         For more information on property binding, see [Template Syntax](../guide/template-syntax.html#property-binding).
 
-        Angular에서, `href`는 더 이상 라우팅에 사용되지 않습니다.
+        Angular에서 `href`는 더 이상 라우팅에 사용되지 않습니다.
         세 번째 예제와 같이, 라우팅은 `routerLink`를 사용합니다.
 
         In Angular, `href` is no longer used for routing. Routing uses `routerLink`, as shown in the third example.
       +makeExample('cb-ajs-quick-reference/ts/src/app/app.component.html', 'router-link')(format="." )
       :marked
-        라우팅에 대한 자세한 내용은, [라우팅 & 내비게이션](../guide/router.html#router-link)을 확인하세요.
+        라우팅에 대한 자세한 내용은 [라우팅 & 내비게이션](../guide/router.html#router-link)을 확인하세요.
 
         For more information on routing, see [Routing & Navigation](../guide/router.html#router-link).
 
@@ -448,7 +449,7 @@ table(width="100%")
         In AngularJS, the `ng-if` directive removes or recreates a portion of the DOM,
         based on an expression. If the expression is false, the element is removed from the DOM.
 
-        이 예제에서, `movies` 배열의 길이가 0보다 크지 않으면 `table` 엘리먼트가 DOM에서 제거됩니다.
+        이 예제에서 `movies` 배열의 길이가 0보다 크지 않으면 `table` 엘리먼트가 DOM에서 제거됩니다.
 
         In this example, the `table` element is removed from the DOM unless the `movies` array has a length greater than zero.
     td
@@ -462,7 +463,7 @@ table(width="100%")
 
         The `*ngIf` directive in Angular works the same as the `ng-if` directive in AngularJS. It removes or recreates a portion of the DOM based on an expression.
 
-        이 예제에서, `movies` 배열에 길이가 없다면, `table` 엘리먼트는 DOM으로부터 제거됩니다.
+        이 예제에서 `movies` 배열에 길이가 없다면, `table` 엘리먼트는 DOM으로부터 제거됩니다.
 
         In this example, the `table` element is removed from the DOM unless the `movies` array has a length.
 
@@ -480,7 +481,7 @@ table(width="100%")
         &lt;input ng-model="vm.favoriteHero"/>
       :marked
         AngularJS에서 `ng-model` 지시자가 폼 컨트롤을 템플릿과 연결된 컨트롤러의 프로퍼티에 바인딩합니다.
-        이렇게하면 **양방향 바인딩**이 제공되어 뷰의 값에 대한 모든 변경 사항이 모델과 동기화되고
+        이렇게 하면 **양방향 바인딩**이 제공되어 뷰의 값에 대한 모든 변경 사항이 모델과 동기화되고
         모델 변경 사항이 뷰의 값과 동기화됩니다.
 
         In AngularJS, the `ng-model` directive binds a form control to a property in the controller associated with the template.
@@ -508,7 +509,7 @@ table(width="100%")
       code-example(format="").
         &lt;tr ng-repeat="movie in vm.movies">
       :marked
-        AngularJS에서, `ng-repeat` 지시자는 지정된 컬렉션의 각 항목에 대해 연관된 DOM 엘리먼트를 반복합니다.
+        AngularJS에서 `ng-repeat` 지시자는 지정된 컬렉션의 각 항목에 대해 연관된 DOM 엘리먼트를 반복합니다.
 
         In AngularJS, the `ng-repeat` directive repeats the associated DOM element
         for each item in the specified collection.
@@ -542,7 +543,7 @@ table(width="100%")
         the `let` keyword identifies `movie` as an input variable;
         the list preposition is `of`, not `in`.
 
-        더 자세한 내용은 [구조 지시자](../guide/structural-directives.html)를 확인하세요.
+        자세한 내용은 [구조 지시자](../guide/structural-directives.html)를 확인하세요.
 
         For more information, see [Structural Directives](../guide/structural-directives.html).
   tr(style=top)
@@ -580,7 +581,7 @@ table(width="100%")
         To conditionally display an element, place the element's `hidden` property in square brackets and
         set it to a quoted template expression that evaluates to the *opposite* of *show*.
 
-        이 예제에서, `favoriteHero` 변수가 true가 아니라면 `div` 엘리먼트는 숨겨져 있습니다.
+        이 예제에서 `favoriteHero` 변수가 true가 아니라면 `div` 엘리먼트는 숨겨져 있습니다.
 
         In this example, the `div` element is hidden if the `favoriteHero` variable is not truthy.
 
@@ -624,7 +625,7 @@ table(width="100%")
       code-example(format="").
         &lt;div ng-style="{color: colorPreference}">
       :marked
-        AngularJS에서, `ng-style` 지시자는 표현식을 기반으로 HTML 요소에 CSS 스타일을 설정합니다.
+        AngularJS에서, `ng-style` 지시자는 표현식을 기반으로 HTML 엘리먼트에 CSS 스타일을 설정합니다.
         이 표현식은 종종 객체의 각 키가 CSS 스타일 이름으로 정의되고 각 값이 스타일에 적합한 값으로 나타나는,
         표현식으로 정의된 키-값 제어 객체입니다.
 
@@ -633,7 +634,7 @@ table(width="100%")
         key of the object defined as a CSS style name, and each value defined as an expression
         that evaluates to a value appropriate for the style.
 
-        이 예제에서, `color` 스타일은 `colorPreference` 변수의 현재값으로 설정됩니다.
+        이 예제에서 `color` 스타일은 `colorPreference` 변수의 현재값으로 설정됩니다.
 
         In the example, the `color` style is set to the current value of the `colorPreference` variable.
     td
@@ -682,13 +683,13 @@ table(width="100%")
             &lt;/div>
         &lt;/div>
       :marked
-        AngularJS에서, `ng-switch` 지시자는 표현식의 현재값을 기반으로 
+        AngularJS에서 `ng-switch` 지시자는 표현식의 현재값을 기반으로 
         템플릿 중 하나를 선택하여 엘리먼트의 내용을 교체합니다.
 
         In AngularJS, the `ng-switch` directive swaps the contents of
         an element by selecting one of the templates based on the current value of an expression.
 
-        이 예에서, `favoriteHero`가 설정되어 있지 않으면 템플릿에 "Please enter ..." 라고 표시됩니다.
+        이 예에서 `favoriteHero`가 설정되어 있지 않으면 템플릿에 "Please enter ..." 라고 표시됩니다.
         만약 `favoriteHero`가 설정되면 컨트롤러 메서드를 호출하여 영화 hero를 확인합니다.
         이 메소드가 `true`를 반환하면, 템플릿에 "Excellent choice!"가 표시됩니다.
         이 메소드가 `false`를 반환하면, 템플릿에 "No movie, sorry!"가 표시됩니다.
@@ -804,7 +805,7 @@ table(width="100%")
         Selects a subset of items from the defined collection, based on the filter criteria.
     td
       :marked
-        ### none
+        ### 대응되는 지시자 없음
         ### none
         성능상의 이유로 비교할 수 있는 파이프가 Angular에 존재하지 않습니다.
         컴포넌트에서 필터링을 모두 수행하세요.
@@ -852,7 +853,7 @@ table(width="100%")
       :marked
         `SlicePipe`는 똑같은 역할을 하지만, JavaScript의 `Slice` 메소드에 따라 *파라미터의 순서가 반대로* 됩니다.
         첫 번째 파라미터는 시작 인덱스입니다; 두 번째는 제한값입니다.
-        AngularJS에서 처럼, 컴포넌트 내에서 이 작업을 코딩하면 성능이 향상 될 수 있습니다.
+        AngularJS에서 처럼 컴포넌트 내에서 이 작업을 코딩하면 성능이 향상 될 수 있습니다.
 
         The `SlicePipe` does the same thing but the *order of the parameters is reversed*, in keeping
         with the JavaScript `Slice` method.
@@ -896,7 +897,7 @@ table(width="100%")
       +makeExample('cb-ajs-quick-reference/ts/src/app/app.component.html', 'number')(format=".")
       :marked
         Angular `number` 파이프도 비슷합니다.
-        위의 두 번째 예제와 같이, 소수 자릿수를 정의 할 때 더 많은 기능을 제공합니다.
+        위의 두 번째 예제와 같이 소수 자릿수를 정의 할 때 더 많은 기능을 제공합니다.
 
         The Angular `number` pipe is similar.
         It provides more functionality when defining
@@ -921,7 +922,7 @@ table(width="100%")
         In this example, the movie title orders the movieList.
     td
       :marked
-        ### none
+        ### 대응되는 지시자 없음
         ### none
         성능상의 이유로 비교할 수 있는 파이프가 Angular에 존재하지 않습니다.
         대신, 컴포넌트 코드를 사용하여 결과를 정렬하거나 나열하세요.
@@ -936,20 +937,20 @@ table(width="100%")
 a(id="controllers-components")
 .l-main-section
 :marked
-  ## Modules/controllers/components
+  ## 모듈/컨트롤러/컴포넌트
   ## Modules/controllers/components
 
   AngularJS와 Angular 모두에서, Angular 모듈은 애플리케이션을 응집력 있는 기능 블록으로 구성하는데 도움이 됩니다.
 
   In both AngularJS and Angular, Angular modules help you organize your application into cohesive blocks of functionality.
 
-  AngularJS에서는, **컨트롤러**에서 모델 및 뷰의 메서드를 제공하는 코드를 작성합니다.
-  Angular에서는, **컴포넌트**를 작성합니다.
+  AngularJS에서는 **컨트롤러**에서 모델 및 뷰의 메서드를 제공하는 코드를 작성합니다.
+  Angular에서는 **컴포넌트**를 작성합니다.
 
   In AngularJS, you write the code that provides the model and the methods for the view in a **controller**.
   In Angular, you build a **component**.
 
-  많은 AngularJS 코드가 JavaScript에 있기 때문에, AngularJS 열에는 JavaScript 코드가 표시됩니다.
+  많은 AngularJS 코드가 JavaScript로 작성되었기 때문에, AngularJS 열에는 JavaScript 코드가 표시됩니다.
   Angular 코드는 TypeScript를 사용하여 표시됩니다.
 
   Because much AngularJS code is in JavaScript, JavaScript code is shown in the AngularJS column.
@@ -971,14 +972,14 @@ table(width="100%")
           ...
         }());
       :marked
-        AngularJS에서, 컨트롤러 코드 주이에서 즉시 호출되는 함수 표현식(또는 IIFE)을 정의하는 경우가 많습니다.
+        AngularJS에서 컨트롤러 코드 주이에서 즉시 호출되는 함수 표현식(또는 IIFE)을 정의하는 경우가 많습니다.
         이로 인해 컨트롤러 코드가 전역 네임스페이스에서 제외되었습니다.
 
         In AngularJS, you often defined an immediately invoked function expression (or IIFE) around your controller code.
         This kept your controller code out of the global namespace.
     td
       :marked
-        ### none
+        ### 대응되는 지시자 없음
         ### none
         ES 2015 모듈을 사용하고 모듈이 네임스페이스를 처리하기 때문에 Angular에서 이 점을 걱정할 필요가 없습니다.
 
@@ -1007,11 +1008,15 @@ table(width="100%")
       +makeExample('cb-ajs-quick-reference/ts/src/app/app.module.1.ts')(format=".")
       :marked
         `NgModule` 데코레이터로 정의된 Angular 모듈은 같은 목적을 수행합니다:
-        - `imports` : 이 모듈이 의존하는 다른 모듈의 목록을 열거합니다.
-        - `declaration` : 컴포넌트, 파이프 및 지시자을 추적합니다.
 
         Angular modules, defined with the `NgModule` decorator, serve the same purpose:
+        
+        - `imports` : 이 모듈이 의존하는 다른 모듈의 목록을 열거합니다.
+        
         - `imports`: specifies the list of other modules that this module depends upon
+
+        - `declaration` : 컴포넌트, 파이프 및 지시자을 추적합니다.
+
         - `declaration`: keeps track of your components, pipes, and directives.
 
         모듈에 대한 자세한 내용은 [Angular 모듈](../guide/ngmodule.html)을 확인하세요.
@@ -1069,7 +1074,7 @@ table(width="100%")
         function MovieListCtrl(movieService) {
         }
       :marked
-        AngularJS에서, 컨트롤러 함수에 모델 및 메서드에 대한 코드를 작성합니다.
+        AngularJS에서 컨트롤러 함수에 모델 및 메서드에 대한 코드를 작성합니다.
 
         In AngularJS, you write the code for the model and methods in a controller function.
     td
@@ -1105,7 +1110,7 @@ table(width="100%")
         In AngularJS, you pass in any dependencies as controller function arguments.
         This example injects a `MovieService`.
 
-        축소(minification) 문제를 막으려면, Angular에 첫 번째 파라미터에 `MovieService` 인스턴스를 삽입해야한다고 명시하세요.
+        축소(minification) 문제를 막기 위해서는 Angular에 첫 번째 파라미터에 `MovieService` 인스턴스를 삽입해야한다고 명시하세요.
 
         To guard against minification problems, tell Angular explicitly
         that it should inject an instance of the `MovieService` in the first parameter.
@@ -1132,13 +1137,13 @@ table(width="100%")
 a(id="style-sheets")
 .l-main-section
 :marked
-  ## 스타일 시트
+  ## 스타일시트
   ## Style sheets
-  스타일 시트는 애플리케이션을 멋지게 만듭니다.
-  AngularJS에서는 전체 애플리케이션의 스타일 시트를 지정합니다.
+  스타일시트는 애플리케이션을 멋지게 만듭니다.
+  AngularJS에서는 전체 애플리케이션의 스타일시트를 지정합니다.
   시간이 지나면서 애플리케이션이 커짐에 따라, 애플리케이션의 여러 부분에 대한 스타일이 병합되어 예기치 않은 결과가 발생할 수 있습니다.
-  Angular에서는 전체 애플리케이션의 스타일 시트를 정의 할 수 있습니다.
-  하지만 이제는 특정 컴포넌트 내에서 스타일 시트를 캡슐화 할 수도 있습니다.
+  Angular에서는 전체 애플리케이션의 스타일시트를 정의 할 수 있습니다.
+  하지만 이제는 특정 컴포넌트 내에서 스타일시트를 캡슐화 할 수도 있습니다.
 
   Style sheets give your application a nice look.
   In AngularJS, you specify the style sheets for your entire application.
@@ -1178,7 +1183,7 @@ table(width="100%")
       :marked
         ### StyleUrls
         ### StyleUrls
-        Angular에서는 특정 컴포넌트의 스타일 시트를 정의하기 위해 
+        Angular에서는 특정 컴포넌트의 스타일시트를 정의하기 위해 
         `@Component` 메타 데이터의 `styles` 또는 `styleUrls` 프로퍼티를 사용할 수 있습니다.
 
         In Angular, you can use the `styles` or `styleUrls` property of the `@Component` metadata to define

--- a/public/docs/ts/latest/cookbook/ajs-quick-reference.jade
+++ b/public/docs/ts/latest/cookbook/ajs-quick-reference.jade
@@ -497,7 +497,7 @@ table(width="100%")
         In Angular, **two-way binding** is denoted by `[()]`, descriptively referred to as a "banana in a box". This syntax is a shortcut for defining both property binding (from the component to the view)
         and event binding (from the view to the component), thereby providing two-way binding.
 
-        ngModel의 양방향 바인딩에 대한 자세한 정보는, [템플릿 구문](../guide/template-syntax.html#ngModel)에서 확인하세요.
+        ngModel의 양방향 바인딩에 대한 자세한 내용은 [템플릿 구문](../guide/template-syntax.html#ngModel)에서 확인하세요.
 
         For more information on two-way binding with ngModel, see [Template Syntax](../guide/template-syntax.html#ngModel).
   tr(style=top)
@@ -522,92 +522,151 @@ table(width="100%")
         ### *ngFor
       +makeExample('cb-ajs-quick-reference/ts/src/app/movie-list.component.html', 'ngFor')(format="." )
       :marked
+        Angular의 `*ngFor` 지시자는 AngularJS의 `ng-repeat` 지시자와 비슷합니다.
+        지정된 컬렉션의 각 항목에 연결된 DOM 엘리먼트를 반복합니다.
+        더 정확하게는 정의된 요소(이 예제에서는`tr`)와 그 내용을 템플릿으로 바꾸고 그 템플릿을 사용하여 목록의 각 항목에 대한 뷰를 인스턴스화합니다.
+
         The `*ngFor` directive in Angular is similar to the `ng-repeat` directive in AngularJS. It repeats the associated DOM element for each item in the specified collection.
         More accurately, it turns the defined element (`tr` in this example) and its contents into a template and
         uses that template to instantiate a view for each item in the list.
+
+
+
+        다른 구문의 차이점에 유의하세요:
+        `ngFor` 앞의 (*)는 필수입니다;
+        `let` 키워드는 `movie`를 입력 변수로 인식합니다.
+        리스트 전치사는 `in`이 아니라 `of`입니다.
 
         Notice the other syntax differences:
         The (*) before `ngFor` is required;
         the `let` keyword identifies `movie` as an input variable;
         the list preposition is `of`, not `in`.
 
+        더 자세한 내용은 [구조 지시자](../guide/structural-directives.html)를 확인하세요.
+
         For more information, see [Structural Directives](../guide/structural-directives.html).
   tr(style=top)
     td
       :marked
+        ### ng-show
         ### ng-show
       code-example(format="").
         &lt;h3 ng-show="vm.favoriteHero">
           Your favorite hero is: {{vm.favoriteHero}}
         &lt;/h3>
       :marked
+        AngularJS에서 `ng-show` 지시자는 표현식을 기반으로 연관된 DOM 엘리먼트를 표시하거나 숨깁니다.
+
         In AngularJS, the `ng-show` directive shows or hides the associated DOM element, based on
         an expression.
+
+        이 예제에서는 `favoriteHero` 변수가 true이면 `div` 엘리먼트가 보여집니다.
 
         In this example, the `div` element is shown if the `favoriteHero` variable is truthy.
     td
       :marked
+        ### `hidden` 프로퍼티에 바인딩
         ### bind to the `hidden` property
       +makeExample('cb-ajs-quick-reference/ts/src/app/movie-list.component.html', 'hidden')(format="." )
       :marked
+        Angular는 프로퍼티 바인딩을 사용합니다; 내장된 *show* 지시자가 없습니다.
+        엘리먼트의 표시와 숨김을 위해, HTML `hidden` 엘리먼트에 바인딩합니다.
+
         Angular, uses property binding; there is no built-in *show* directive.
         For hiding and showing elements, bind to the HTML `hidden` property.
+
+        조건부로 엘리먼트를 표시하려면, 엘리먼트의 `hidden` 속성을 대괄호 안에 넣고 *show*의 *반대*로 평가되는 따옴표 붙은 템플릿 표현식으로 설정하세요.
 
         To conditionally display an element, place the element's `hidden` property in square brackets and
         set it to a quoted template expression that evaluates to the *opposite* of *show*.
 
+        이 예제에서, `favoriteHero` 변수가 true가 아니라면 `div` 엘리먼트는 숨겨져 있습니다.
+
         In this example, the `div` element is hidden if the `favoriteHero` variable is not truthy.
+
+        프로퍼티 바인딩에 대한 자세한 내용은 [템플릿 구문](../guide/template-syntax.html#property-binding)에서 확인하세요.
 
         For more information on property binding, see [Template Syntax](../guide/template-syntax.html#property-binding).
   tr(style=top)
     td
       :marked
         ### ng-src
+        ### ng-src
       code-example(format="").
         &lt;img ng-src="{{movie.imageurl}}">
       :marked
+        `ng-src` 지시자는 AngularJS가 `src` 프로퍼티를 전처리하여 
+        브라우저가 해당 URL을 가져가기 전에 바인딩 표현식을 적절한 URL로 대체 할 수 있도록 합니다.
+
         The `ng-src` directive allows AngularJS to preprocess the `src` property so that it
         can replace the binding expression with the appropriate URL before the browser
         fetches from that URL.
     td
       :marked
+        ### `src` 프로퍼티에 바인딩
         ### bind to the `src` property
       +makeExample('cb-ajs-quick-reference/ts/src/app/app.component.html', 'src')(format="." )
       :marked
+        Angular는 프로퍼티 바인딩을 사용합니다; 내장된 *src* 지시자가 없습니다.
+        `src` 프로퍼티를 대괄호 안에 넣고 따옴표가 붙은 템플릿 표현식으로 설정하세요.
+
         Angular, uses property binding; there is no built-in *src* directive.
         Place the `src` property in square brackets and set it to a quoted template expression.
+
+        프로퍼티 바인딩에 대한 자세한 내용은 [템플릿 구문](../guide/template-syntax.html#property-binding)을 확인하세요.
 
         For more information on property binding, see [Template Syntax](../guide/template-syntax.html#property-binding).
   tr(style=top)
     td
       :marked
         ### ng-style
+        ### ng-style
       code-example(format="").
         &lt;div ng-style="{color: colorPreference}">
       :marked
+        AngularJS에서, `ng-style` 지시자는 표현식을 기반으로 HTML 요소에 CSS 스타일을 설정합니다.
+        이 표현식은 종종 객체의 각 키가 CSS 스타일 이름으로 정의되고 각 값이 스타일에 적합한 값으로 나타나는,
+        표현식으로 정의된 키-값 제어 객체입니다.
+
         In AngularJS, the `ng-style` directive sets a CSS style on an HTML element
         based on an expression. That expression is often a key-value control object with each
         key of the object defined as a CSS style name, and each value defined as an expression
         that evaluates to a value appropriate for the style.
 
+        이 예제에서, `color` 스타일은 `colorPreference` 변수의 현재값으로 설정됩니다.
+
         In the example, the `color` style is set to the current value of the `colorPreference` variable.
     td
       :marked
         ### ngStyle
+        ### ngStyle
       +makeExample('cb-ajs-quick-reference/ts/src/app/app.component.html', 'ngStyle')(format="." )
       :marked
+        Angular에서 `ngStyle` 지시자는 비슷하게 동작합니다.
+        표현식을 기반으로 HTML 엘리먼트에 CSS 스타일을 설정합니다.
+
         In Angular, the `ngStyle` directive works similarly. It sets a CSS style on an HTML element based on an expression.
+
+        첫 번째 예제에서 `color` 스타일은 `colorPreference` 변수의 현재값으로 설정됩니다.
 
         In the first example, the `color` style is set to the current value of the `colorPreference` variable.
 
+        또한 Angular에는 단일 스타일을 설정하는 좋은 방법인 **스타일 바인딩**이 있습니다. 
+        이것은 두 번째 예제에 나와 있습니다.
+
         Angular also has **style binding**, which is good way to set a single style. This is shown in the second example.
 
+        스타일 바인딩에 대한 자세한 내용은 [템플릿 구문](../guide/template-syntax.html#style-binding)을 확인하세요.
+
         For more information on style binding, see [Template Syntax](../guide/template-syntax.html#style-binding).
+
+        ngStyle 지시자에 대한 자세한 내용은 [템플릿 구문](../guide/template-syntax.html#style-binding)을 확인하세요.
 
         For more information on the ngStyle directive, see [Template Syntax](../guide/template-syntax.html#ngStyle).
   tr(style=top)
     td
       :marked
+        ### ng-switch
         ### ng-switch
       code-example(format="").
         &lt;div ng-switch="vm.favoriteHero &&
@@ -623,8 +682,16 @@ table(width="100%")
             &lt;/div>
         &lt;/div>
       :marked
+        AngularJS에서, `ng-switch` 지시자는 표현식의 현재값을 기반으로 
+        템플릿 중 하나를 선택하여 엘리먼트의 내용을 교체합니다.
+
         In AngularJS, the `ng-switch` directive swaps the contents of
         an element by selecting one of the templates based on the current value of an expression.
+
+        이 예에서, `favoriteHero`가 설정되어 있지 않으면 템플릿에 "Please enter ..." 라고 표시됩니다.
+        만약 `favoriteHero`가 설정되면 컨트롤러 메서드를 호출하여 영화 hero를 확인합니다.
+        이 메소드가 `true`를 반환하면, 템플릿에 "Excellent choice!"가 표시됩니다.
+        이 메소드가 `false`를 반환하면, 템플릿에 "No movie, sorry!"가 표시됩니다.
 
         In this example, if `favoriteHero` is not set, the template displays "Please enter ...".
         If `favoriteHero` is set, it checks the movie hero by calling a controller method.
@@ -633,10 +700,20 @@ table(width="100%")
     td
       :marked
         ### ngSwitch
+        ### ngSwitch
       +makeExample('cb-ajs-quick-reference/ts/src/app/movie-list.component.html', 'ngSwitch')(format="." )
       :marked
+        Angular에서 `ngSwitch` 지시자는 비슷하게 작동합니다.
+        `*ngSwitchCase`가 현재의 `ngSwitch` 표현식 값과 일치하는 엘리먼트를 표시합니다.
+
         In Angular, the `ngSwitch` directive works similarly.
         It displays an element whose `*ngSwitchCase` matches the current `ngSwitch` expression value.
+
+        이 예에서 `favoriteHero`가 설정되어 있지 않으면 `ngSwitch`값은 `null`이고,
+        `*ngSwitchDefault`는 "Please enter ..."라고 표시됩니다.
+        만약 `favoriteHero`가 설정되면 앱은 컴포넌트 메소드를 호출하여 영화 hero를 확인합니다.
+        이 메소드가`true`를 반환하면, 앱은 `*ngSwitchCase="true"`를 선택하고 "Excellent choice!"를 표시합니다.
+        이 메소드가`false`를 반환하면, 앱은 `*ngSwitchCase="false"`를 선택하고 "No movie, sorry!"를 표시합니다.
 
         In this example, if `favoriteHero` is not set, the `ngSwitch` value is `null`
         and `*ngSwitchDefault` displays, "Please enter ...".
@@ -644,7 +721,11 @@ table(width="100%")
         If that method returns `true`, the app selects `*ngSwitchCase="true"` and displays: "Excellent choice!"
         If that methods returns `false`, the app selects `*ngSwitchCase="false"` and displays: "No movie, sorry!"
 
+        이 예제에서는 `ngSwitchCase`와 `ngSwitchDefault` 앞에있는 (*)가 필수입니다.
+
         The (*) before `ngSwitchCase` and `ngSwitchDefault` is required in this example.
+
+        ngSwitch 지시자에 대한 자세한 내용은 [템플릿 구문](../guide/template-syntax.html#ngSwitch)을 확인하세요.
 
         For more information on the ngSwitch directive, see [Template Syntax](../guide/template-syntax.html#ngSwitch).
 :marked
@@ -653,7 +734,12 @@ table(width="100%")
 a(id="filters-pipes")
 .l-main-section
 :marked
+  ## 필터/파이프
   ## Filters/pipes
+  Angular **파이프**는 AngularJS **필터**와 유사하게 템플릿의 데이터에 대한 포맷 지정 및 변형을 제공합니다.
+  AngularJS에 내장된 많은 필터는 그에 대응되는 Angular 파이프가 있습니다.
+  파이프에 대한 자세한 내용은 [파이프](../guide/pipes.html)를 확인하세요.
+
   Angular **pipes** provide formatting and transformation for data in our template, similar to AngularJS **filters**.
   Many of the built-in filters in AngularJS have corresponding pipes in Angular.
   For more information on pipes, see [Pipes](../guide/pipes.html).
@@ -668,72 +754,106 @@ table(width="100%")
     td
       :marked
         ### currency
+        ### currency
       code-example.
         &lt;td>{{movie.price | currency}}&lt;/td>
       :marked
+        숫자를 통화 형식으로 변환합니다.
+
         Formats a number as a currency.
     td
       :marked
         ### currency
+        ### currency
       +makeExample('cb-ajs-quick-reference/ts/src/app/app.component.html', 'currency')(format="." )
       :marked
+        일부 파라미터들이 변경되었지만 Angular의 `currency` 파이프도 비슷합니다.
+
         The Angular `currency` pipe is similar although some of the parameters have changed.
   tr(style=top)
     td
       :marked
         ### date
+        ### date
       code-example.
         &lt;td>{{movie.releaseDate  | date}}&lt;/td>
       :marked
+        요청된 형식에 근거해 날짜를 문자열로 포맷합니다.
+
         Formats a date to a string based on the requested format.
     td
       :marked
         ### date
+        ### date
       +makeExample('cb-ajs-quick-reference/ts/src/app/app.component.html', 'date')(format=".")
       :marked
+        Angular의 `date` 파이프도 비슷합니다.
+
         The Angular `date` pipe is similar.
 
   tr(style=top)
     td
       :marked
         ### filter
+        ### filter
       code-example.
         &lt;tr ng-repeat="movie in movieList | filter: {title:listFilter}">
       :marked
+        필터 기준에 따라 정의된 컬렉션에서 항목의 하위 집합을 선택합니다.
+
         Selects a subset of items from the defined collection, based on the filter criteria.
     td
       :marked
         ### none
+        ### none
+        성능상의 이유로 비교할 수 있는 파이프가 Angular에 존재하지 않습니다.
+        컴포넌트에서 필터링을 모두 수행하세요.
+        여러 템플릿에서 동일한 필터링 코드가 필요한 경우, 커스텀 파이프를 만드는 것을 고려해보세요.
+
         For performance reasons, no comparable pipe exists in Angular. Do all your filtering in the component. If you need the same filtering code in several templates, consider building a custom pipe.
 
   tr(style=top)
     td
       :marked
         ### json
+        ### json
       code-example.
         &lt;pre>{{movie | json}}&lt;/pre>
       :marked
+        JavaScript 객체를 JSON 문자열로 변환합니다. 이것은 디버깅에 유용합니다.
+
         Converts a JavaScript object into a JSON string. This is useful for debugging.
     td
       :marked
         ### json
+        ### json
       +makeExample('cb-ajs-quick-reference/ts/src/app/app.component.html', 'json')(format=".")
       :marked
+        Angular의 `json` 파이프도 같은 역할을 합니다.
+
         The Angular `json` pipe does the same thing.
   tr(style=top)
     td
       :marked
         ### limitTo
+        ### limitTo
       code-example.
         &lt;tr ng-repeat="movie in movieList | limitTo:2:0">
       :marked
+        컬렉션에서 (선택사항인) 시작 인덱스 (0)에서 시작하여 항목의 첫번째 파라미터인 (2)까지 선택합니다.
+
         Selects up to the first parameter (2) number of items from the collection
         starting (optionally) at the beginning index (0).
     td
       :marked
         ### slice
+        ### slice
       +makeExample('cb-ajs-quick-reference/ts/src/app/app.component.html', 'slice')(format=".")
       :marked
+        `SlicePipe`는 똑같은 역할을 하지만, JavaScript의 `Slice` 메소드에 따라 *파라미터의 순서가 반대로* 됩니다.
+        첫 번째 파라미터는 시작 인덱스입니다; 두 번째는 제한값입니다.
+        AngularJS에서 처럼, 컴포넌트 내에서 이 작업을 코딩하면 성능이 향상 될 수 있습니다.
+
         The `SlicePipe` does the same thing but the *order of the parameters is reversed*, in keeping
         with the JavaScript `Slice` method.
         The first parameter is the starting index; the second is the limit.
@@ -742,32 +862,47 @@ table(width="100%")
     td
       :marked
         ### lowercase
+        ### lowercase
       code-example.
         &lt;div>{{movie.title | lowercase}}&lt;/div>
       :marked
+        문자열을 소문자로 변환합니다.
+
         Converts the string to lowercase.
     td
       :marked
         ### lowercase
+        ### lowercase
       +makeExample('cb-ajs-quick-reference/ts/src/app/app.component.html', 'lowercase')(format=".")
       :marked
+        Angular의 `lowercase` 파이프도 같은 역할을 합니다.
+
         The Angular `lowercase` pipe does the same thing.
   tr(style=top)
     td
       :marked
         ### number
+        ### number
       code-example.
         &lt;td>{{movie.starRating  | number}}&lt;/td>
       :marked
+        숫자를 문자로 포맷합니다.
+
         Formats a number as text.
     td
       :marked
         ### number
+        ### number
       +makeExample('cb-ajs-quick-reference/ts/src/app/app.component.html', 'number')(format=".")
       :marked
+        Angular `number` 파이프도 비슷합니다.
+        위의 두 번째 예제와 같이, 소수 자릿수를 정의 할 때 더 많은 기능을 제공합니다.
+
         The Angular `number` pipe is similar.
         It provides more functionality when defining
         the decimal places, as shown in the second example above.
+
+        Angular에는 세 번째 예제에서와 같이 숫자를 지역 백분율로 포맷하는 `percent` 파이프도 있습니다.
 
         Angular also has a `percent` pipe, which formats a number as a local percentage
         as shown in the third example.
@@ -775,14 +910,23 @@ table(width="100%")
     td
       :marked
         ### orderBy
+        ### orderBy
       code-example.
         &lt;tr ng-repeat="movie in movieList | orderBy : 'title'">
       :marked
+        표현식에 지정된 순서대로 콜렉션을 표시합니다.
+        이 예제에서 영화 title에 의해 movieList를 나열합니다.
+
         Displays the collection in the order specified by the expression.
         In this example, the movie title orders the movieList.
     td
       :marked
         ### none
+        ### none
+        성능상의 이유로 비교할 수 있는 파이프가 Angular에 존재하지 않습니다.
+        대신, 컴포넌트 코드를 사용하여 결과를 정렬하거나 나열하세요.
+        만약 여러 템플릿에서 동일한 순서 또는 정렬된 코드가 필요한 경우, 커스텀 파이프를 만드는 것을 고려해 보세요.
+
         For performance reasons, no comparable pipe exists in Angular.
         Instead, use component code to order or sort results. If you need the same ordering or sorting code in several templates, consider building a custom pipe.
 
@@ -793,10 +937,20 @@ a(id="controllers-components")
 .l-main-section
 :marked
   ## Modules/controllers/components
+  ## Modules/controllers/components
+
+  AngularJS와 Angular 모두에서, Angular 모듈은 애플리케이션을 응집력 있는 기능 블록으로 구성하는데 도움이 됩니다.
+
   In both AngularJS and Angular, Angular modules help you organize your application into cohesive blocks of functionality.
+
+  AngularJS에서는, **컨트롤러**에서 모델 및 뷰의 메서드를 제공하는 코드를 작성합니다.
+  Angular에서는, **컴포넌트**를 작성합니다.
 
   In AngularJS, you write the code that provides the model and the methods for the view in a **controller**.
   In Angular, you build a **component**.
+
+  많은 AngularJS 코드가 JavaScript에 있기 때문에, AngularJS 열에는 JavaScript 코드가 표시됩니다.
+  Angular 코드는 TypeScript를 사용하여 표시됩니다.
 
   Because much AngularJS code is in JavaScript, JavaScript code is shown in the AngularJS column.
   The Angular code is shown using TypeScript.
@@ -811,41 +965,62 @@ table(width="100%")
     td
       :marked
         ### IIFE
+        ### IIFE
       code-example.
         (function () {
           ...
         }());
       :marked
+        AngularJS에서, 컨트롤러 코드 주이에서 즉시 호출되는 함수 표현식(또는 IIFE)을 정의하는 경우가 많습니다.
+        이로 인해 컨트롤러 코드가 전역 네임스페이스에서 제외되었습니다.
+
         In AngularJS, you often defined an immediately invoked function expression (or IIFE) around your controller code.
         This kept your controller code out of the global namespace.
     td
       :marked
         ### none
+        ### none
+        ES 2015 모듈을 사용하고 모듈이 네임스페이스를 처리하기 때문에 Angular에서 이 점을 걱정할 필요가 없습니다.
+
         You don't need to worry about this in Angular because you use ES 2015 modules
         and modules handle the namespacing for you.
+
+        모듈에 대한 자세한 내용은 [아키텍쳐 개요](../guide/architecture.html#module)를 확인하세요.
 
         For more information on modules, see [Architecture Overview](../guide/architecture.html#module).
   tr(style=top)
     td
       :marked
+        ### Angular 모듈
         ### Angular modules
       code-example.
         angular.module("movieHunter", ["ngRoute"]);
       :marked
+        AngularJS에서 Angular 모듈은 컨트롤러, 서비스 및 기타 코드를 추적합니다.
+        두 번째 인수는 이 모듈이 의존하는 다른 모듈의 목록을 정의합니다.
+
         In AngularJS, an Angular module keeps track of controllers, services, and other code. The second argument defines the list of other modules that this module depends upon.
     td
       :marked
+        ### Angular 모듈
         ### Angular modules
       +makeExample('cb-ajs-quick-reference/ts/src/app/app.module.1.ts')(format=".")
       :marked
+        `NgModule` 데코레이터로 정의된 Angular 모듈은 같은 목적을 수행합니다:
+        - `imports` : 이 모듈이 의존하는 다른 모듈의 목록을 열거합니다.
+        - `declaration` : 컴포넌트, 파이프 및 지시자을 추적합니다.
+
         Angular modules, defined with the `NgModule` decorator, serve the same purpose:
         - `imports`: specifies the list of other modules that this module depends upon
         - `declaration`: keeps track of your components, pipes, and directives.
+
+        모듈에 대한 자세한 내용은 [Angular 모듈](../guide/ngmodule.html)을 확인하세요.
 
         For more information on modules, see [Angular Modules](../guide/ngmodule.html).
   tr(style=top)
     td
       :marked
+        ### 컨트롤러 등록
         ### Controller registration
       code-example.
         angular
@@ -854,64 +1029,101 @@ table(width="100%")
                       ["movieService",
                        MovieListCtrl]);
       :marked
+        AngularJS는 적절한 Angular 모듈을 찾는 코드가 각 컨트롤러에 있고, 컨트롤러에 해당 모듈을 등록합니다.
+
         AngularJS, has code in each controller that looks up an appropriate Angular module
         and registers the controller with that module.
+
+        첫 번째 인수는 컨트롤러 이름입니다.
+        두 번째 인수는 이 컨트롤러에 삽입된 모든 종속성의 문자열 이름과 컨트롤러 함수에 대한 참조를 정의합니다.
 
         The first argument is the controller name. The second argument defines the string names of
         all dependencies injected into this controller, and a reference to the controller function.
     td
       :marked
+        ### 컴포넌트 데코레이터
         ### Component Decorator
       +makeExample('cb-ajs-quick-reference/ts/src/app/movie-list.component.ts', 'component')(format=".")
       :marked
+        Angular는 컴포넌트 클래스에 데코레이터를 추가하여 필수 메타데이터를 제공합니다.
+        컴포넌트 데코레이터는 클래스가 컴포넌트임을 선언하고, 
+        선택자 (또는 태그) 및 해당 템플릿과 같은 해당 컴포넌트에 대한 메타데이터를 제공합니다.
+
         Angular, adds a decorator to the component class to provide any required metadata.
         The Component decorator declares that the class is a component and provides metadata about
         that component such as its selector (or tag) and its template.
 
+        이것은 템플릿을 컴포넌트 클래스에서 정의된 코드와 연결하는 방법입니다.
+
         This is how you associate a template with code, which is defined in the component class.
+
+        자세한 내용은 아키텍쳐 개요 페이지의 [컴포넌트](../guide/architecture.html#components)를 확인하세요.
 
         For more information, see the [Components](../guide/architecture.html#components) section of the Architecture Overview page.
   tr(style=top)
     td
       :marked
+        ### 컨트롤러 함수
         ### Controller function
       code-example.
         function MovieListCtrl(movieService) {
         }
       :marked
+        AngularJS에서, 컨트롤러 함수에 모델 및 메서드에 대한 코드를 작성합니다.
+
         In AngularJS, you write the code for the model and methods in a controller function.
     td
       :marked
+        ### 컴포넌트 클래스
         ### Component class
       +makeExample('cb-ajs-quick-reference/ts/src/app/movie-list.component.ts', 'class')(format=".")
       :marked
+        Angular에서 컴포넌트 클래스를 만듭니다.
+
         In Angular, you create a component class.
 
+        참고: AngularJS와 함께 TypeScript를 사용하는 경우, 반드시 `export` 키워드를 사용하여 컴포넌트 클래스를 익스포트하세요.
+
         NOTE: If you are using TypeScript with AngularJS, you must use the `export` keyword to export the component class.
+
+        자세한 내용은 아키텍쳐 개요 페이지의 [컴포넌트](../guide/architecture.html#components)를 확인하세요.
 
         For more information, see the [Components](../guide/architecture.html#components) section of the Architecture Overview page.
   tr(style=top)
     td
       :marked
+        ### 의존성 주입
         ### Dependency injection
       code-example.
         MovieListCtrl.$inject = ['MovieService'];
         function MovieListCtrl(movieService) {
         }
       :marked
+        AngularJS는 컨트롤러 함수 인수로써 의존성을 전달합니다.
+        이 예제는 `MovieService`를 삽입합니다.
+
         In AngularJS, you pass in any dependencies as controller function arguments.
         This example injects a `MovieService`.
+
+        축소(minification) 문제를 막으려면, Angular에 첫 번째 파라미터에 `MovieService` 인스턴스를 삽입해야한다고 명시하세요.
 
         To guard against minification problems, tell Angular explicitly
         that it should inject an instance of the `MovieService` in the first parameter.
     td
       :marked
+        ### 의존성 주입
         ### Dependency injection
       +makeExample('cb-ajs-quick-reference/ts/src/app/movie-list.component.ts', 'di')(format=".")
       :marked
+        Angular에서는 컴포넌트 클래스 생성자에 대한 인수로 의존성을 전달합니다.
+        이 예제는 `MovieService`를 삽입합니다.
+        첫 번째 파라미터의 TypeScript 유형은 축소 후에도 주입 할 내용을 Angular에 알려줍니다.
+
         In Angular, you pass in dependencies as arguments to the component class constructor.
         This example injects a `MovieService`.
         The first parameter's TypeScript type tells Angular what to inject, even after minification.
+
+        자세한 내용은 아키텍쳐 개요의 [의존성 주입](../guide/architecture.html#dependency-injection)을 확인하세요.
 
         For more information, see the [Dependency Injection](../guide/architecture.html#dependency-injection) section of the Architecture Overview.
 :marked
@@ -920,7 +1132,14 @@ table(width="100%")
 a(id="style-sheets")
 .l-main-section
 :marked
+  ## 스타일 시트
   ## Style sheets
+  스타일 시트는 애플리케이션을 멋지게 만듭니다.
+  AngularJS에서는 전체 애플리케이션의 스타일 시트를 지정합니다.
+  시간이 지나면서 애플리케이션이 커짐에 따라, 애플리케이션의 여러 부분에 대한 스타일이 병합되어 예기치 않은 결과가 발생할 수 있습니다.
+  Angular에서는 전체 애플리케이션의 스타일 시트를 정의 할 수 있습니다.
+  하지만 이제는 특정 컴포넌트 내에서 스타일 시트를 캡슐화 할 수도 있습니다.
+
   Style sheets give your application a nice look.
   In AngularJS, you specify the style sheets for your entire application.
   As the application grows over time, the styles for the many parts of the application
@@ -936,25 +1155,38 @@ table(width="100%")
   tr(style=top)
     td
       :marked
+        ### Link 태그
         ### Link tag
       code-example.
         &lt;link href="styles.css" rel="stylesheet" />
       :marked
+        AngularJS는 `index.html` 파일의 head 섹션에 있는 `link` 태그를 사용하여 애플리케이션의 스타일을 정의합니다.
+
         AngularJS, uses a `link` tag in the head section of the `index.html` file
         to define the styles for the application.
     td
       :marked
+        ### Link 태그
         ### Link tag
       +makeExample('cb-ajs-quick-reference/ts/src/index.html', 'style')(format=".")
       :marked
+        Angular에서 link 태그를 사용하여 애플리케이션의 스타일을 `index.html` 파일에서 계속 정의 할 수 있습니다.
+        그러나 이제는 컴포넌트의 스타일을 캡슐화 할 수도 있습니다.
+
         In Angular, you can continue to use the link tag to define the styles for your application in the `index.html` file.
         But now you can also encapsulate styles for your components.
       :marked
         ### StyleUrls
+        ### StyleUrls
+        Angular에서는 특정 컴포넌트의 스타일 시트를 정의하기 위해 
+        `@Component` 메타 데이터의 `styles` 또는 `styleUrls` 프로퍼티를 사용할 수 있습니다.
+
         In Angular, you can use the `styles` or `styleUrls` property of the `@Component` metadata to define
         a style sheet for a particular component.
       +makeExample('cb-ajs-quick-reference/ts/src/app/movie-list.component.ts', 'style-url')(format=".")
       :marked
+        이렇게 하면 애플리케이션의 다른 부분에 영향을 끼치지 않는 개별 컴포넌트에 적합한 스타일을 설정할 수 있습니다.
+
         This allows you to set appropriate styles for individual components that won’t leak into
         other parts of the application.
 :marked

--- a/public/docs/ts/latest/cookbook/ajs-quick-reference.jade
+++ b/public/docs/ts/latest/cookbook/ajs-quick-reference.jade
@@ -1,30 +1,60 @@
 include ../_util-fns
 a(id="top")
 :marked
+  _Angular_는 오늘 그리고 앞으로 Angular를 위한 이름입니다.
+  _AngularJS_는 모든 v1.x 버전 Angular의 이름입니다.
+
   _Angular_ is the name for the Angular of today and tomorrow.
   _AngularJS_ is the name for all v1.x versions of Angular.
+
+  이 가이드는 AngularJS 구문을 그에 맞는 Angular 구문으로 매핑하여 
+  AngularJS를 Angular로 전환하도록 도움을 줄겁니다.
 
   This guide helps you transition from AngularJS to Angular
   by mapping AngularJS syntax to the equivalent Angular syntax.
 
 :marked
+  **<live-example name="cb-ajs-quick-reference"></live-example>에서 Angular 구문을 확인하세요**.
+
   **See the Angular syntax in this <live-example name="cb-ajs-quick-reference"></live-example>**.
 
+  ## 내용
+  
   ## Contents
+
+  이 페이지에는 아래의 내용이 있습니다:
+  
   This page covers:
+
+  * [템플릿 기본사항](#template-basics) - 바인딩과 지역 변수.
+
   * [Template basics](#template-basics) - binding and local variables.
+
+  * [템플릿 지시자](#template-directives) - 내장 지시자 `ngIf`와 `ngClass`.
 
   * [Template directives](#template-directives) - built-in directives `ngIf` and `ngClass`.
 
+  * [필터/파이프](#filters-pipes) - Angular에서 *파이프*로 알려진, 내장 *필터*.
+
   * [Filters/pipes](#filters-pipes) - built-in *filters*, known as *pipes* in Angular.
 
+  * [모듈/컨트롤러/컴포넌트](#controllers-components) - Angular의 *모듈*은 AngularJS의 *모듈*과 약간 다르고,
+  *컨트롤러*는 Angular의 *컴포넌트*입니다.
+
   * [Modules/controllers/components](#controllers-components) - *modules* in Angular are slightly different from *modules* in AngularJS, and *controllers* are *components* in Angular.
+
+  * [스타일 시트](#style-sheets) - AngularJS 보다 더 많은 CSS 옵션 제공.
 
   * [Style sheets](#style-sheets) - more options for CSS than in AngularJS.
 
 .l-main-section
 :marked
+  ## 템플릿 기본사항
   ## Template basics
+  
+  템플릿은 Angular 애플리케이션의 사용자가 직면하게 되는 부분으로, HTML로 작성됩니다.
+  다음 표에는 주요 AngularJS 템플릿 기능과 그에 해당하는 Angular 템플릿 구문이 나와 있습니다.
+
   Templates are the user-facing part of an Angular application and are written in HTML.
   The following table lists some of the key AngularJS template features with their equivalent Angular template syntax.
 
@@ -38,64 +68,97 @@ table(width="100%")
   tr(style=top)
     td
       :marked
+        ### 바인딩/삽입식
         ### Bindings/interpolation
       code-example.
          Your favorite hero is: {{vm.favoriteHero}}
       :marked
+        AngularJS에서 중괄호로 묶인 표현은 단방향 바인딩을 나타냅니다.
+        이것은 엘리먼트의 값을 템플릿과 연관된 컨트롤러의 프로퍼티에 바인딩합니다.
+
         In AngularJS, an expression in curly braces denotes one-way binding.
         This binds the value of the element to a property in the controller
         associated with this template.
+
+        `controller as`구문을 사용할 때,
+        바인딩의 출처에 대해 특정해야하기 때문에 바인딩은 컨트롤러 별칭(`vm` 또는`$ctrl`)으로 시작됩니다.
 
         When using the `controller as` syntax,
         the binding is prefixed with the controller alias (`vm` or `$ctrl`) because you
         have to be specific about the source of the binding.
     td
       :marked
+        ### 바인딩/삽입식
         ### Bindings/interpolation
       +makeExample('cb-ajs-quick-reference/ts/src/app/movie-list.component.html', 'interpolation')(format="." )
       :marked
+        Angular에서 중괄호로 묶인 템플릿 표현식은 여전히 단방향 바인딩을 나타냅니다.
+        이것은 엘리먼트의 값을 컴포넌트의 프로퍼티에 바인당합니다.
+        바인딩 컨텍스트는 암시적이고 있고 항상 관련된 컴포넌트이므로, 참조 변수가 필요하지 않습니다.
+
         In Angular, a template expression in curly braces still denotes one-way binding.
         This binds the value of the element to a property of the component.
         The context of the binding is implied and is always the
         associated component, so it needs no reference variable.
 
+        자세한 내용은, 템플릿 구문 페이지의 [삽입식](../guide/template-syntax.html#interpolation) 부분을 확인하세요.
+
         For more information, see the [Interpolation](../guide/template-syntax.html#interpolation) section of the Template Syntax page.
   tr(style=top)
     td
       :marked
+        ### 필터
         ### Filters
       code-example.
          &lt;td>{{movie.title | uppercase}}&lt;/td>
       :marked
+        AngularJS 템플릿의 출력을 필터링하려면, 파이프 문자 (|) 와 하나 이상의 필터를 사용하십시오.
+
         To filter output in AngularJS templates, use the pipe character (|) and one or more filters.
+
+        이 예제는 `title` 프로퍼티를 대문자로 필터링합니다.
 
         This example filters the `title` property to uppercase.
     td
       :marked
+        ### 파이프
         ### Pipes
       +makeExample('cb-ajs-quick-reference/ts/src/app/app.component.html', 'uppercase')(format="." )
       :marked
+        Angular에서는 출력을 필터링하기 위해 파이프 (|) 문자와 유사한 구문을 사용하지만, 이제는 그것들을 **파이프**라고 부릅니다.
+        AngularJS의 내장 필터 중 (전부는 아니지만) 대다수는 Angular의 내장 파이프입니다.
+
         In Angular you use similar syntax with the pipe (|) character to filter output, but now you call them **pipes**.
         Many (but not all) of the built-in filters from AngularJS are
         built-in pipes in Angular.
+
+        자세한 내용은,아래의 [필터/파이프](#filters-pipes) 머릿말을 확인하세요.
 
         For more information, see the heading [Filters/pipes](#filters-pipes) below.
   tr(style=top)
     td
       :marked
+        ### 지역 변수
         ### Local variables
       code-example(format="").
         &lt;tr ng-repeat="movie in vm.movies">
           &lt;td>{{movie.title}}&lt;/td>
         &lt;/tr>
       :marked
+        여기, `movie`는 사용자가 정의한 지역변수입니다.
+
         Here, `movie` is a user-defined local variable.
     td
       :marked
+        ### 입력 변수
         ### Input variables
       +makeExample('cb-ajs-quick-reference/ts/src/app/app.component.html', 'local')(format="." )
       :marked
+        Angular는 `let` 키워드를 사용하여 명시적으로 정의된 실제 템플릿 입력 변수를 가지고 있습니다.
+
         Angular has true template input variables that are explicitly defined using the `let` keyword.
+
+        자세한 내용은, 템플릿 구문 페이지의 [ngFor 세부구문](../guide/template-syntax.html#ngForMicrosyntax) 부분을 확인하세요.
 
         For more information, see the [ngFor micro-syntax](../guide/template-syntax.html#ngForMicrosyntax) section of the Template Syntax page.
 :marked
@@ -103,7 +166,13 @@ table(width="100%")
 
 .l-main-section
 :marked
+  ## 템플릿 지시자
   ## Template directives
+
+  AngularJS는 템플릿에 대해 70개가 넘는 내장 지시자를 제공합니다.
+  그것들 중 많은 것들은 보다 유능하고 표현력이 좋은 바인딩 시스템 때문에 Angular에서 필요하지 않습니다.
+  다음은 AngularJS에 내장된 주요 지시자 중 일부와 그에 해당하는 Angular의 항목입니다.
+
   AngularJS provides more than seventy built-in directives for templates.
   Many of them aren't needed in Angular because of its more capable and expressive binding system.
   The following are some of the key AngularJS built-in directives and their equivalents in Angular.
@@ -118,59 +187,93 @@ table(width="100%")
     td
       :marked
         ### ng-app
+        ### ng-app
       code-example.
         &lt;body ng-app="movieHunter">
       :marked
+        애플리케이션의 시작 프로세스는 **부트스트래핑** 이라고 합니다.
+
         The application startup process is called **bootstrapping**.
+
+        코드에서 AngularJS 앱을 부트스트랩 할 수 있지만,
+        많은 애플리케이션은 `ng-app` 지시자을 사용하여 선언적으로 부트스트랩을 수행하여,
+        애플리케이션의 모듈(`movieHunter`) 이름을 제공합니다.
 
         Although you can bootstrap an AngularJS app in code,
         many applications bootstrap declaratively with the `ng-app` directive,
         giving it the name of the application's module (`movieHunter`).
     td
       :marked
+        ### 부트스트래핑
         ### Bootstrapping
       +makeExample('cb-ajs-quick-reference/ts/src/main.ts','','main.ts')(format="." )
       <br>
       +makeExample('cb-ajs-quick-reference/ts/src/app/app.module.1.ts','','app.module.ts')(format="." )
 
       :marked
+        Angular에는 부트스트랩 지시자가 없습니다.
+        코드에서 앱을 실행하려면, 애플리케이션의 루트 모듈(`AppModule`)을 `main.ts`에 명시적으로 부트스트래핑하고
+        애플리케이션의 루트 컴포넌트 (`AppComponent`)는 `app.module.ts`에 부트스트랩하세요.
+        
         Angular doesn't have a bootstrap directive.
         To launch the app in code, explicitly bootstrap the application's root module (`AppModule`)
         in `main.ts`
         and the application's root component (`AppComponent`) in `app.module.ts`.
+
+        좀 더 자세한 내용은 [설치](../guide/setup.html) 페이지를 확인하세요.
 
         For more information see the [Setup](../guide/setup.html) page.
   tr(style=top)
     td
       :marked
         ### ng-class
+        ### ng-class
       code-example(format="").
         &lt;div ng-class="{active: isActive}">
         &lt;div ng-class="{active: isActive,
                            shazam: isImportant}">
       :marked
+        AngularJS에서는 `ng-class` 지시자가 표현식을 기반으로 CSS 클래스를 포함/제외합니다.
+        대게 이 표현식은 CSS 클래스 이름으로 정의된 객체의 키와 부울 값으로 평가된 템플릿 표현식으로 정의된 객체의 값으로 이루어진, 키-값 제어 객체입니다.
+
         In AngularJS, the `ng-class` directive includes/excludes CSS classes
         based on an expression. That expression is often a key-value control object with each
         key of the object defined as a CSS class name, and each value defined as a template expression
         that evaluates to a Boolean value.
 
+        첫 번째 예제에서, `isActive`가 true이면 `active` 클래스가 엘리먼트에 적용됩니다.
+
         In the first example, the `active` class is applied to the element if `isActive` is true.
+    
+        두 번째 예제와 같이, 여러 클래스를 지정할 수 있습니다.
 
         You can specify multiple classes, as shown in the second example.
     td
       :marked
         ### ngClass
+        ### ngClass
       +makeExample('cb-ajs-quick-reference/ts/src/app/app.component.html', 'ngClass')(format="." )
       :marked
+        Angular에서 `ngClass` 지시자는 비슷하게 작동합니다.
+        표현식을 기반으로 CSS 클래스를 포함/제외합니다.
+        
         In Angular, the `ngClass` directive works similarly.
         It includes/excludes CSS classes based on an expression.
 
+        첫 번째 예제에서 `isActive`가 true이면 `active` 클래스가 엘리먼트에 적용됩니다.
+
         In the first example, the `active` class is applied to the element if `isActive` is true.
+
+        두 번째 예제와 같이, 여러 클래스를 지정할 수 있습니다.
 
         You can specify multiple classes, as shown in the second example.
 
+        또한 Angular에는 세 번째 예제에서와 같이 단일 클래스를 추가하거나 제거하는 좋은 방법인 **클래스 바인딩**이 있습니다.
+
         Angular also has **class binding**, which is a good way to add or remove a single class,
         as shown in the third example.
+
+        자세한 내용은, 템플릿 구문 페이지의 [속성, 클래스 및 스타일 바인딩](../guide/template-syntax.html#other-bindings) 부분을 확인하세요.
 
         For more information see the [Attribute, Class, and Style Bindings](../guide/template-syntax.html#other-bindings) section of the Template Syntax page.
 
@@ -178,35 +281,58 @@ table(width="100%")
     td
       :marked
         ### ng-click
+        ### ng-click
       code-example(format="").
         &lt;button ng-click="vm.toggleImage()">
         &lt;button ng-click="vm.toggleImage($event)">
       :marked
+        AngularJS에서, `ng-click` 지시자를 사용하여 엘리먼트를 클릭 할 때 사용자 정의 동작을 지정할 수 있습니다.
+
         In AngularJS, the `ng-click` directive allows you to specify custom behavior when an element is clicked.
 
+        첫 번째 예제에서, 사용자가 버튼을 클릭하면,`vm` `controller as`가 참조하는 컨트롤러의 `toggleImage()`메소드가 실행됩니다.
+
         In the first example, when the user clicks the button, the `toggleImage()` method in the controller referenced by the `vm` `controller as` alias is executed.
+
+        두 번째 예제는 이벤트에 대한 세부사항을 컨트롤러에 제공하는, `$event` 객체를 전달하는 방법을 보여줍니다.
 
         The second example demonstrates passing in the `$event` object, which provides details about the event
         to the controller.
     td
       :marked
+        ### `click`이벤트에 바인드
         ### bind to the `click` event
       +makeExample('cb-ajs-quick-reference/ts/src/app/app.component.html', 'event-binding')(format="." )
       :marked
+        AngularJS 이벤트에 기반한 지시자는 Angular에 존재하지 않습니다.
+        더 정확하게 이야기 하면, **이벤트 바인딩**을 사용하여 템플릿 뷰에서 컴포넌트로 단방향 바인딩을 정의하세요.
+
         AngularJS event-based directives do not exist in Angular.
         Rather, define one-way binding from the template view to the component using **event binding**.
+
+        이벤트 바인딩의 경우, 괄호 안에 대상 이벤트의 이름을 정의하고 등호의 오른쪽에 따옴표로 묶인 템플릿 명령문을 지정하세요.
+        Angular는 대상 이벤트에 대한 이벤트 핸들러를 설정합니다.
+        이벤트가 발생하면 핸들러는 템플리트 명령문을 실행합니다.
 
         For event binding, define the name of the target event within parenthesis and
         specify a template statement, in quotes, to the right of the equals. Angular then
         sets up an event handler for the target event. When the event is raised, the handler
         executes the template statement.
+        
+        첫 번째 예제에서, 사용자가 버튼을 클릭하면 연결된 컴포넌트의 `toggleImage()`메소드가 실행됩니다.
 
         In the first example, when a user clicks the button, the `toggleImage()` method in the associated component is executed.
+        
+        두 번째 예제는 이벤트에 대한 세부사항을 컴포넌트에 제공하는, `$event` 객체를 전달하는 방법을 보여줍니다.
 
         The second example demonstrates passing in the `$event` object, which provides details about the event
         to the component.
 
+        DOM 이벤트 목록은 다음을 확인하세요: https://developer.mozilla.org/en-US/docs/Web/Events.
+
         For a list of DOM events, see: https://developer.mozilla.org/en-US/docs/Web/Events.
+
+        자세한 내용은, 템플릿 구문 페이지의 [이벤트 바인딩](../guide/template-syntax.html#event-binding) 부분을 확인하세요.
 
         For more information, see the [Event Binding](../guide/template-syntax.html#event-binding) section of the Template Syntax page.
 
@@ -214,19 +340,29 @@ table(width="100%")
     td
       :marked
         ### ng-controller
+        ### ng-controller
       code-example(format="").
         &lt;div ng-controller="MovieListCtrl as vm">
       :marked
+        AngularJS에서, `ng-controller` 지시자는 컨트롤러를 뷰에 연결합니다.
+        `ng-controller` (또는 라우팅의 일부로서 컨트롤러를 정의)를 사용하면 뷰가 그 뷰와 연관된 컨트롤러 코드에 연결됩니다.
+
         In AngularJS, the `ng-controller` directive attaches a controller to the view.
         Using the `ng-controller` (or defining the controller as part of the routing) ties the
         view to the controller code associated with that view.
     td
       :marked
+        ### 컴포넌트 데코레이터
         ### Component decorator
       +makeExample('cb-ajs-quick-reference/ts/src/app/movie-list.component.ts', 'component')(format="." )
       :marked
+        Angular에서 템플릿은 더 이상 관련 컨트롤러를 지정하지 않습니다.
+        오히려, 컴포넌트가 연관된 클래스를 컴포넌트 클래스 데코레이터의 일부로 지정합니다.
+
         In Angular, the template no longer specifies its associated controller.
         Rather, the component specifies its associated template as part of the component class decorator.
+
+        좀 더 자세한 내용은, [아키텍쳐 개요](../guide/architecture.html#component)를 확인하세요.
 
         For more information, see [Architecture Overview](../guide/architecture.html#component).
 
@@ -234,63 +370,104 @@ table(width="100%")
     td
       :marked
         ### ng-hide
+        ### ng-hide
+        AngularJS에서 `ng-hide` 지시자는 표현식을 기반으로 연관된 HTML 요소를 표시하거나 숨깁니다.
+        좀 더 자세한 내용은 [ng-show](#ng-show)를 확인하세요.
+
         In AngularJS, the `ng-hide` directive shows or hides the associated HTML element based on
         an expression. For more information, see [ng-show](#ng-show).
     td
       :marked
+        ### `hidden` 프로퍼티에 바인딩
         ### bind to the `hidden` property
+        Angular에서는 프로퍼티 바인딩을 사용합니다; 내장된 *hide* 지시자가 없습니다.
+        좀 더 자세한 내용은 [ng-show](#ng-show)를 확인하세요.
+
         In Angular, you use property binding; there is no built-in *hide* directive.
         For more information, see [ng-show](#ng-show).
   tr(style=top)
     td
       :marked
         ### ng-href
+        ### ng-href
       code-example(format="").
         &lt;a ng-href="angularDocsUrl">Angular Docs&lt;/a>
       :marked
+        `ng-href` 지시자는 AngularJS가 브라우저에서 URL을 가져오기 전에 바인딩 표현식을 적절한 URL로 대체 할 수 있도록 `href` 속성을 전처리 할 수 있게 합니다.
+
         The `ng-href` directive allows AngularJS to preprocess the `href` property so that it
         can replace the binding expression with the appropriate URL before the browser
         fetches from that URL.
+
+        AngularJS에서는 `ng-href`가 내비게이션의 일부로 라우트를 활성화하는 데 자주 사용됩니다.
 
         In AngularJS, the `ng-href` is often used to activate a route as part of navigation.
       code-example(format="").
         &lt;a ng-href="#movies">Movies&lt;/a>
       :marked
+        Angular에서 라우팅은 다르게 처리됩니다.
+
         Routing is handled differently in Angular.
     td
       :marked
+        ### `href` 프로퍼티에 바인딩
         ### bind to the `href` property
       +makeExample('cb-ajs-quick-reference/ts/src/app/app.component.html', 'href')(format="." )
       :marked
+        Angular는 프로퍼티 바인딩을 사용합니다; 내장된 *href* 지시자가 없습니다.
+        엘리먼트의 `href` 프로퍼티를 대괄호로 묶고, 따옴표가 붙은 템플릿 표현식으로 설정하세요.
+
         Angular, uses property binding; there is no built-in *href* directive.
         Place the element's `href` property in square brackets and set it to a quoted template expression.
 
+        프로퍼티 바인딩에 대한 좀 더 자세한 내용은, [템플릿 구문](../guide/template-syntax.html#property-binding)을 확인하세요.
+
         For more information on property binding, see [Template Syntax](../guide/template-syntax.html#property-binding).
+
+        Angular에서, `href`는 더 이상 라우팅에 사용되지 않습니다.
+        세 번째 예제와 같이, 라우팅은 `routerLink`를 사용합니다.
 
         In Angular, `href` is no longer used for routing. Routing uses `routerLink`, as shown in the third example.
       +makeExample('cb-ajs-quick-reference/ts/src/app/app.component.html', 'router-link')(format="." )
       :marked
+        라우팅에 대한 자세한 내용은, [라우팅 & 내비게이션](../guide/router.html#router-link)을 확인하세요.
+
         For more information on routing, see [Routing & Navigation](../guide/router.html#router-link).
 
   tr(style=top)
     td
       :marked
         ### ng-if
+        ### ng-if
       code-example(format="").
         &lt;table ng-if="movies.length">
       :marked
+        AngularJS에서 `ng-if` 지시자는 표현식을 기반으로 DOM의 일부를 제거하거나 다시 만듭니다.
+        만약 표현식이 거짓이면, 엘리먼트가 DOM에서 제거됩니다.
+
         In AngularJS, the `ng-if` directive removes or recreates a portion of the DOM,
         based on an expression. If the expression is false, the element is removed from the DOM.
+
+        이 예제에서, `movies` 배열의 길이가 0보다 크지 않으면 `table` 엘리먼트가 DOM에서 제거됩니다.
 
         In this example, the `table` element is removed from the DOM unless the `movies` array has a length greater than zero.
     td
       :marked
         ### *ngIf
+        ### *ngIf
       +makeExample('cb-ajs-quick-reference/ts/src/app/movie-list.component.html', 'ngIf')(format="." )
       :marked
+        Angular의 `*ngIf` 지시자는 AngularJS의 `ng-if` 지시자와 동일하게 동작합니다. 
+        `*ngIf` 지시자는 표현식을 기반으로 DOM의 일부를 제거하거나 다시 만듭니다.
+
         The `*ngIf` directive in Angular works the same as the `ng-if` directive in AngularJS. It removes or recreates a portion of the DOM based on an expression.
 
+        이 예제에서, `movies` 배열에 길이가 없다면, `table` 엘리먼트는 DOM으로부터 제거됩니다.
+
         In this example, the `table` element is removed from the DOM unless the `movies` array has a length.
+
+        이 예제에서는 `ngIf` 앞에 (*)가 필요합니다.
+        자세한 내용은 [구조 지시자](../guide/structural-directives.html)에서 확인하세요.
 
         The (*) before `ngIf` is required in this example.
         For more information, see [Structural Directives](../guide/structural-directives.html).
@@ -298,33 +475,50 @@ table(width="100%")
     td
       :marked
         ### ng-model
+        ### ng-model
       code-example(format="").
         &lt;input ng-model="vm.favoriteHero"/>
       :marked
+        AngularJS에서 `ng-model` 지시자가 폼 컨트롤을 템플릿과 연결된 컨트롤러의 프로퍼티에 바인딩합니다.
+        이렇게하면 **양방향 바인딩**이 제공되어 뷰의 값에 대한 모든 변경 사항이 모델과 동기화되고
+        모델 변경 사항이 뷰의 값과 동기화됩니다.
+
         In AngularJS, the `ng-model` directive binds a form control to a property in the controller associated with the template.
         This provides **two-way binding**, whereby any change made to the value in the view is synchronized with the model, and any change to the model is synchronized with the value in the view.
     td
       :marked
         ### ngModel
+        ### ngModel
       +makeExample('cb-ajs-quick-reference/ts/src/app/movie-list.component.html', 'ngModel')(format="." )
       :marked
+        Angular에서 **양방향 바인딩**은 `[()]`로 표시되며, "상자 안 바나나"라고도 묘사됩니다.
+        이 구문은 (컴포넌트에서 뷰로의) 프로퍼티 바인딩과 (뷰에서 컴포넌트로) 이벤트 바인딩 을 모두 정의하여, 양방향 바인딩을 제공하는 지름길입니다.
+
         In Angular, **two-way binding** is denoted by `[()]`, descriptively referred to as a "banana in a box". This syntax is a shortcut for defining both property binding (from the component to the view)
         and event binding (from the view to the component), thereby providing two-way binding.
+
+        ngModel의 양방향 바인딩에 대한 자세한 정보는, [템플릿 구문](../guide/template-syntax.html#ngModel)에서 확인하세요.
 
         For more information on two-way binding with ngModel, see [Template Syntax](../guide/template-syntax.html#ngModel).
   tr(style=top)
     td
       :marked
         ### ng-repeat
+        ### ng-repeat
       code-example(format="").
         &lt;tr ng-repeat="movie in vm.movies">
       :marked
+        AngularJS에서, `ng-repeat` 지시자는 지정된 컬렉션의 각 항목에 대해 연관된 DOM 엘리먼트를 반복합니다.
+
         In AngularJS, the `ng-repeat` directive repeats the associated DOM element
         for each item in the specified collection.
+
+        이 예제에서 테이블 행 (`tr`) 엘리먼트는 movie 컬렉션의 각 movie 객체에 대해 반복됩니다.
 
         In this example, the table row (`tr`) element repeats for each movie object in the collection of movies.
     td
       :marked
+        ### *ngFor
         ### *ngFor
       +makeExample('cb-ajs-quick-reference/ts/src/app/movie-list.component.html', 'ngFor')(format="." )
       :marked

--- a/public/docs/ts/latest/glossary.jade
+++ b/public/docs/ts/latest/glossary.jade
@@ -509,7 +509,7 @@ a#directives
     HTML elements, components, and other directives. They are usually represented
     as HTML attributes, hence the name.
 
-    1. [구조형 지시자](#structural-directive)는 일반적으로 HTML의 요소나 자식요소들을 더하거나, 빼거나, 조작하여 HTML 레이아웃을 만들거나 수정할 때 사용합니다.
+    1. [구조 지시자](#structural-directive)는 일반적으로 HTML의 요소나 자식요소들을 더하거나, 빼거나, 조작하여 HTML 레이아웃을 만들거나 수정할 때 사용합니다.
 
     1. [Structural directives](#structural-directive) that
     shape or reshape HTML layout, typically by adding and removing elements in the DOM.
@@ -1040,19 +1040,19 @@ a#snake-case
 a#structural-directive
 a#structural-directives
 :marked
-  ## 구조형 지시자 (Structural Directive)
+  ## 구조 지시자 (Structural Directive)
   ## Structural directives
 
 .l-sub-section
   :marked
     [지사자](#directive) 유형 중 하나로 일반적으로 HTML의 요소나 자식요소들을 더하거나, 빼거나, 
-    조작하여 HTML 레이아웃을 만들거나 수정할 때 사용합니다. 구조형 지시자 유형의 대표적인 예로 "조건형 요소" 지시자 `ngIf`와 "반복형" 지사자 `ngFor`가 있습니다.
+    조작하여 HTML 레이아웃을 만들거나 수정할 때 사용합니다. 구조 지시자 유형의 대표적인 예로 "조건형 엘리먼트" 지시자 `ngIf`와 "반복형" 지사자 `ngFor`가 있습니다.
 
     A category of [directive](#directive) that can
     shape or reshape HTML layout, typically by adding and removing elements in the DOM.
     The `ngIf` "conditional element" directive and the `ngFor` "repeater" directive are well-known examples.
 
-    추가적인 내용은 [_구조형 지시자_](!{docsLatest}/guide/structural-directives.html)가이드를 참고하세요.
+    추가적인 내용은 [_구조 지시자_](!{docsLatest}/guide/structural-directives.html)가이드를 참고하세요.
 
     Read more in the [_Structural Directives_](!{docsLatest}/guide/structural-directives.html) guide.
     

--- a/public/docs/ts/latest/guide/change-log.jade
+++ b/public/docs/ts/latest/guide/change-log.jade
@@ -8,7 +8,7 @@ block includes
   The Angular documentation is a living document with continuous improvements.
   This log calls attention to recent significant changes.
 
-  ## 템플릿 구문 / 구조 지시문 : 새로 고침 (2017-02-06)
+  ## 템플릿 구문 / 구조 지시자 : 새로 고침 (2017-02-06)
   ## Template Syntax/Structural Directives: refreshed (2017-02-06)
   명확성, 정확성 및 현재 권장 사례를 위해 [_템플릿-구문_](template-syntax.html) 및 [_구조 지시자_](structural-directives.html) 가이드가 크게 수정되었습니다.
   `<ng-container>`에 대해 논의합니다.

--- a/public/docs/ts/latest/guide/template-syntax.jade
+++ b/public/docs/ts/latest/guide/template-syntax.jade
@@ -2055,7 +2055,7 @@ a#structural-directives
   ## 내장 _구조_ 지시문
   ## Built-in _structural_ directives
 
-  구조 지시문은 HTML 레이아웃을 담당합니다.
+  구조 지시자는 HTML 레이아웃을 담당합니다.
   일반적으로 DOM은 호스트 요소를 추가, 제거 및 조작하여 DOM _구조_를 형성하거나 변형합니다.
 
   Structural directives are responsible for HTML layout.
@@ -2078,7 +2078,7 @@ a#structural-directives
   * to use [`<ng-container>`](structural-directives.html#ngcontainer "<ng-container>")
   to group elements when there is no suitable host element for the directive.
   
-  * 자신의 구조 지시문 작성 방법
+  * 자신의 구조 지시자 작성 방법
 
   * how to write your own structural directive.
   
@@ -2374,7 +2374,7 @@ figure.image-display
   The `emotion` value in this example is a string, but the switch value can be of any type.
 
   **`[ngSwitch]`에 바인딩하세요**. `*ngSwitch`를 설정하려고 하면 오류가 발생할 겁니다.
-  `NgSwitch`는 *구조* 지시ㅏ가 아닌 *속성* 지시자입니다.
+  `NgSwitch`는 *구조* 지시자가 아닌 *속성* 지시자입니다.
   그것은 동반자 지시자의 동작을 변경합니다.
   DOM에 직접적으로 영향을주지 않습니다.
 

--- a/public/docs/ts/latest/tutorial/toh-pt2.jade
+++ b/public/docs/ts/latest/tutorial/toh-pt2.jade
@@ -399,7 +399,7 @@ code-example(language="sh" class="code-shell").
     `ngIf` puts the hero detail content into the DOM and evaluates the nested bindings.
   .l-sub-section
     :marked
-      `ngIf`와 `ngFor`는 “구조적 지시자(structural directives)” 라고 불립니다. 
+      `ngIf`와 `ngFor`는 “구조 지시자(structural directives)” 라고 불립니다. 
       왜냐하면 이것들은 DOM의 구조를 변경하기 때문입니다. 
       다시말해, 이것들은 Angular에게 DOM안에 표시할 콘텐츠 구조를 알려줍니다.
 
@@ -407,7 +407,7 @@ code-example(language="sh" class="code-shell").
       structure of portions of the DOM.
       In other words, they give structure to the way Angular displays content in the DOM.
 
-      `ngIf`, `ngFor`와 다른 구조 지시자(structural directives) 에 대해
+      `ngIf`, `ngFor`와 다른 구조 지시자(structural directives)에 대해
       [Structural Directives](../guide/structural-directives.html) 및
       [Template Syntax](../guide/template-syntax.html#directives) 챕터에서 더 자세하게 알아보세요.
 

--- a/public/translate/ko/translate.js
+++ b/public/translate/ko/translate.js
@@ -76,12 +76,13 @@ var sourceVisible = localStorage.getItem('source-visible') === 'true';
     return count;
   }
 
-  /**
+  /*
    * Process block elements. The first element is original english, the
    * second element is translated one.
    * @param current the first element.
    * @returns {boolean} Is success?
    */
+   
   function processBlock(current) {
     var sibling = current.nextElementSibling;
 
@@ -98,7 +99,7 @@ var sourceVisible = localStorage.getItem('source-visible') === 'true';
             $current.addClass('translated');
             $sibling.addClass('original-english');
             $current.after($sibling);
-            $sibling.on('click', function (event) {
+            $current.on('click', function (event) {
               // for nested structure.
               event.stopPropagation();
               $sibling.toggleClass('hidden');


### PR DESCRIPTION
- Trans(cookbook/ajs-quick-reference.jade)
- Fix(change the translated word - 'structural-directive' to '구조 지시자')
